### PR TITLE
fix: wranglerのcompatibility_dateを修正

### DIFF
--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -1,6 +1,6 @@
 name = "tsundoku-dragon-api"
 main = "src/index.ts"
-compatibility_date = "2025-12-24"
+compatibility_date = "2025-12-23"
 
 [dev]
 port = 8787


### PR DESCRIPTION
## Summary
- wranglerの`compatibility_date`を`2025-12-24`から`2025-12-23`に修正
- 未来の日付はwranglerがサポートしていないため、ローカル開発時にエラーが発生していた

## Test plan
- [x] `npm run dev:api` でローカル起動を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)