### PR TITLE
feat: 本のCRUD API（登録・取得）を実装

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,7 +12,10 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.962.0",
     "@aws-sdk/lib-dynamodb": "^3.962.0",
-    "hono": "^4.0.0"
+    "@hono/zod-validator": "^0.7.6",
+    "hono": "^4.0.0",
+    "nanoid": "^5.1.6",
+    "zod": "^4.3.4"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.0.0",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,8 +2,11 @@ import { DescribeTableCommand } from '@aws-sdk/client-dynamodb';
 import { Hono } from 'hono';
 
 import { createDynamoDBClient, type Env } from './lib/dynamodb';
+import books from './routes/books';
 
 const app = new Hono<{ Bindings: Env }>();
+
+app.route('/books', books);
 
 app.get('/', (c) => {
   return c.json({ message: 'Tsundoku Dragon API' });

--- a/apps/api/src/repositories/bookRepository.test.ts
+++ b/apps/api/src/repositories/bookRepository.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BookRepository } from './bookRepository';
+import type { Book } from '@tsundoku-dragon/shared';
+
+vi.mock('../lib/dynamodb', () => ({
+  createDynamoDBClient: vi.fn(() => ({
+    send: vi.fn(),
+  })),
+}));
+
+describe('BookRepository', () => {
+  const mockEnv = {
+    AWS_ACCESS_KEY_ID: 'test',
+    AWS_SECRET_ACCESS_KEY: 'test',
+    AWS_REGION: 'ap-northeast-1',
+    DYNAMODB_TABLE_NAME: 'test-table',
+  };
+
+  const mockBook: Book = {
+    id: 'book-123',
+    userId: 'user-456',
+    title: 'テスト本',
+    totalPages: 100,
+    currentPage: 0,
+    status: 'reading',
+    skills: ['TypeScript'],
+    round: 1,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+  };
+
+  let repository: BookRepository;
+  let mockSend: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    repository = new BookRepository(mockEnv);
+    mockSend = vi.mocked(
+      (repository as unknown as { client: { send: ReturnType<typeof vi.fn> } })
+        .client.send
+    );
+  });
+
+  describe('save', () => {
+    it('正しいPK/SKでアイテムを保存する', async () => {
+      mockSend.mockResolvedValueOnce({});
+
+      await repository.save(mockBook);
+
+      expect(mockSend).toHaveBeenCalledOnce();
+      const command = mockSend.mock.calls[0][0];
+      expect(command.input).toEqual({
+        TableName: 'test-table',
+        Item: {
+          PK: 'USER#user-456',
+          SK: 'BOOK#book-123',
+          ...mockBook,
+        },
+      });
+    });
+  });
+
+  describe('findByUserId', () => {
+    it('begins_withで正しくクエリする', async () => {
+      mockSend.mockResolvedValueOnce({
+        Items: [{ PK: 'USER#user-456', SK: 'BOOK#book-123', ...mockBook }],
+      });
+
+      const result = await repository.findByUserId('user-456');
+
+      expect(mockSend).toHaveBeenCalledOnce();
+      const command = mockSend.mock.calls[0][0];
+      expect(command.input).toEqual({
+        TableName: 'test-table',
+        KeyConditionExpression: 'PK = :pk AND begins_with(SK, :skPrefix)',
+        ExpressionAttributeValues: {
+          ':pk': 'USER#user-456',
+          ':skPrefix': 'BOOK#',
+        },
+      });
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('book-123');
+    });
+
+    it('空の結果を正しく処理する', async () => {
+      mockSend.mockResolvedValueOnce({ Items: [] });
+
+      const result = await repository.findByUserId('user-456');
+
+      expect(result).toEqual([]);
+    });
+
+    it('Itemsがundefinedの場合も空配列を返す', async () => {
+      mockSend.mockResolvedValueOnce({});
+
+      const result = await repository.findByUserId('user-456');
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('findById', () => {
+    it('存在する本を取得する', async () => {
+      mockSend.mockResolvedValueOnce({
+        Item: { PK: 'USER#user-456', SK: 'BOOK#book-123', ...mockBook },
+      });
+
+      const result = await repository.findById('user-456', 'book-123');
+
+      expect(mockSend).toHaveBeenCalledOnce();
+      const command = mockSend.mock.calls[0][0];
+      expect(command.input).toEqual({
+        TableName: 'test-table',
+        Key: {
+          PK: 'USER#user-456',
+          SK: 'BOOK#book-123',
+        },
+      });
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe('book-123');
+    });
+
+    it('存在しない本はnullを返す', async () => {
+      mockSend.mockResolvedValueOnce({});
+
+      const result = await repository.findById('user-456', 'not-exist');
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/apps/api/src/repositories/bookRepository.ts
+++ b/apps/api/src/repositories/bookRepository.ts
@@ -1,0 +1,67 @@
+import { PutCommand, QueryCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
+import type { Book } from '@tsundoku-dragon/shared';
+import { createDynamoDBClient, type Env } from '../lib/dynamodb';
+
+export class BookRepository {
+  private client;
+  private tableName: string;
+
+  constructor(env: Env) {
+    this.client = createDynamoDBClient(env);
+    this.tableName = env.DYNAMODB_TABLE_NAME;
+  }
+
+  private buildPK(userId: string): string {
+    return `USER#${userId}`;
+  }
+
+  private buildSK(bookId: string): string {
+    return `BOOK#${bookId}`;
+  }
+
+  async save(book: Book): Promise<void> {
+    await this.client.send(
+      new PutCommand({
+        TableName: this.tableName,
+        Item: {
+          PK: this.buildPK(book.userId),
+          SK: this.buildSK(book.id),
+          ...book,
+        },
+      })
+    );
+  }
+
+  async findByUserId(userId: string): Promise<Book[]> {
+    const result = await this.client.send(
+      new QueryCommand({
+        TableName: this.tableName,
+        KeyConditionExpression: 'PK = :pk AND begins_with(SK, :skPrefix)',
+        ExpressionAttributeValues: {
+          ':pk': this.buildPK(userId),
+          ':skPrefix': 'BOOK#',
+        },
+      })
+    );
+    return (result.Items ?? []).map((item) => this.toBook(item));
+  }
+
+  async findById(userId: string, bookId: string): Promise<Book | null> {
+    const result = await this.client.send(
+      new GetCommand({
+        TableName: this.tableName,
+        Key: {
+          PK: this.buildPK(userId),
+          SK: this.buildSK(bookId),
+        },
+      })
+    );
+    return result.Item ? this.toBook(result.Item) : null;
+  }
+
+  private toBook(item: Record<string, unknown>): Book {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { PK, SK, ...book } = item;
+    return book as unknown as Book;
+  }
+}

--- a/apps/api/src/routes/books.test.ts
+++ b/apps/api/src/routes/books.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Hono } from 'hono';
+import books from './books';
+import type { Book } from '@tsundoku-dragon/shared';
+
+vi.mock('nanoid', () => ({
+  nanoid: vi.fn(() => 'generated-id-123'),
+}));
+
+const mockSave = vi.fn();
+const mockFindByUserId = vi.fn();
+const mockFindById = vi.fn();
+
+vi.mock('../repositories/bookRepository', () => ({
+  BookRepository: class {
+    save = mockSave;
+    findByUserId = mockFindByUserId;
+    findById = mockFindById;
+  },
+}));
+
+describe('Books Routes', () => {
+  const mockEnv = {
+    AWS_ACCESS_KEY_ID: 'test',
+    AWS_SECRET_ACCESS_KEY: 'test',
+    AWS_REGION: 'ap-northeast-1',
+    DYNAMODB_TABLE_NAME: 'test-table',
+  };
+
+  const app = new Hono().route('/books', books);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('POST /books', () => {
+    it('201と作成した本を返す', async () => {
+      mockSave.mockResolvedValueOnce(undefined);
+
+      const res = await app.request(
+        '/books',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-User-Id': 'test-user',
+          },
+          body: JSON.stringify({ title: 'テスト本', totalPages: 100 }),
+        },
+        mockEnv
+      );
+
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as Book;
+      expect(body.id).toBe('generated-id-123');
+      expect(body.title).toBe('テスト本');
+      expect(body.totalPages).toBe(100);
+      expect(body.userId).toBe('test-user');
+      expect(body.currentPage).toBe(0);
+      expect(body.status).toBe('reading');
+    });
+
+    it('X-User-Idがない場合はdev-user-001を使う', async () => {
+      mockSave.mockResolvedValueOnce(undefined);
+
+      const res = await app.request(
+        '/books',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ title: 'テスト本', totalPages: 100 }),
+        },
+        mockEnv
+      );
+
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as Book;
+      expect(body.userId).toBe('dev-user-001');
+    });
+
+    it('titleがない場合は400を返す', async () => {
+      const res = await app.request(
+        '/books',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ totalPages: 100 }),
+        },
+        mockEnv
+      );
+
+      expect(res.status).toBe(400);
+    });
+
+    it('totalPagesがない場合は400を返す', async () => {
+      const res = await app.request(
+        '/books',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ title: 'テスト本' }),
+        },
+        mockEnv
+      );
+
+      expect(res.status).toBe(400);
+    });
+
+    it('totalPagesが0以下の場合は400を返す', async () => {
+      const res = await app.request(
+        '/books',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ title: 'テスト本', totalPages: 0 }),
+        },
+        mockEnv
+      );
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('GET /books', () => {
+    it('本の一覧を返す', async () => {
+      const mockBooks: Book[] = [
+        {
+          id: 'book-1',
+          userId: 'test-user',
+          title: '本1',
+          totalPages: 100,
+          currentPage: 0,
+          status: 'reading',
+          skills: [],
+          round: 1,
+          createdAt: '2024-01-01T00:00:00Z',
+          updatedAt: '2024-01-01T00:00:00Z',
+        },
+      ];
+      mockFindByUserId.mockResolvedValueOnce(mockBooks);
+
+      const res = await app.request(
+        '/books',
+        {
+          headers: { 'X-User-Id': 'test-user' },
+        },
+        mockEnv
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { books: Book[] };
+      expect(body.books).toHaveLength(1);
+      expect(body.books[0].title).toBe('本1');
+    });
+
+    it('空の一覧を返す', async () => {
+      mockFindByUserId.mockResolvedValueOnce([]);
+
+      const res = await app.request(
+        '/books',
+        {
+          headers: { 'X-User-Id': 'test-user' },
+        },
+        mockEnv
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { books: Book[] };
+      expect(body.books).toEqual([]);
+    });
+  });
+
+  describe('GET /books/:id', () => {
+    it('存在する本を返す', async () => {
+      const mockBook: Book = {
+        id: 'book-123',
+        userId: 'test-user',
+        title: 'テスト本',
+        totalPages: 100,
+        currentPage: 0,
+        status: 'reading',
+        skills: [],
+        round: 1,
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+      };
+      mockFindById.mockResolvedValueOnce(mockBook);
+
+      const res = await app.request(
+        '/books/book-123',
+        {
+          headers: { 'X-User-Id': 'test-user' },
+        },
+        mockEnv
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Book;
+      expect(body.id).toBe('book-123');
+      expect(body.title).toBe('テスト本');
+    });
+
+    it('存在しない本は404を返す', async () => {
+      mockFindById.mockResolvedValueOnce(null);
+
+      const res = await app.request(
+        '/books/not-exist',
+        {
+          headers: { 'X-User-Id': 'test-user' },
+        },
+        mockEnv
+      );
+
+      expect(res.status).toBe(404);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe('Book not found');
+    });
+  });
+});

--- a/apps/api/src/routes/books.ts
+++ b/apps/api/src/routes/books.ts
@@ -1,0 +1,41 @@
+import { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import type { Env } from '../lib/dynamodb';
+import { BookService } from '../services/bookService';
+import { createBookSchema } from '../types/api';
+
+const books = new Hono<{ Bindings: Env }>();
+
+const getUserId = (c: {
+  req: { header: (name: string) => string | undefined };
+}): string => {
+  return c.req.header('X-User-Id') ?? 'dev-user-001';
+};
+
+books.post('/', zValidator('json', createBookSchema), async (c) => {
+  const input = c.req.valid('json');
+  const userId = getUserId(c);
+  const service = new BookService(c.env);
+  const book = await service.createBook(userId, input);
+  return c.json(book, 201);
+});
+
+books.get('/', async (c) => {
+  const userId = getUserId(c);
+  const service = new BookService(c.env);
+  const bookList = await service.listBooks(userId);
+  return c.json({ books: bookList });
+});
+
+books.get('/:id', async (c) => {
+  const userId = getUserId(c);
+  const bookId = c.req.param('id');
+  const service = new BookService(c.env);
+  const book = await service.getBook(userId, bookId);
+  if (!book) {
+    return c.json({ error: 'Book not found' }, 404);
+  }
+  return c.json(book);
+});
+
+export default books;

--- a/apps/api/src/services/bookService.test.ts
+++ b/apps/api/src/services/bookService.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { BookService } from './bookService';
+import type { Book } from '@tsundoku-dragon/shared';
+
+vi.mock('nanoid', () => ({
+  nanoid: vi.fn(() => 'generated-id-123'),
+}));
+
+const mockSave = vi.fn();
+const mockFindByUserId = vi.fn();
+const mockFindById = vi.fn();
+
+vi.mock('../repositories/bookRepository', () => ({
+  BookRepository: class {
+    save = mockSave;
+    findByUserId = mockFindByUserId;
+    findById = mockFindById;
+  },
+}));
+
+describe('BookService', () => {
+  const mockEnv = {
+    AWS_ACCESS_KEY_ID: 'test',
+    AWS_SECRET_ACCESS_KEY: 'test',
+    AWS_REGION: 'ap-northeast-1',
+    DYNAMODB_TABLE_NAME: 'test-table',
+  };
+
+  let service: BookService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+
+    service = new BookService(mockEnv);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('createBook', () => {
+    const input = {
+      title: 'テスト本',
+      totalPages: 100,
+      skills: ['TypeScript'],
+    };
+
+    it('IDを生成する', async () => {
+      const book = await service.createBook('user-123', input);
+
+      expect(book.id).toBe('generated-id-123');
+    });
+
+    it('currentPageを0で初期化する', async () => {
+      const book = await service.createBook('user-123', input);
+
+      expect(book.currentPage).toBe(0);
+    });
+
+    it('statusをreadingで初期化する', async () => {
+      const book = await service.createBook('user-123', input);
+
+      expect(book.status).toBe('reading');
+    });
+
+    it('roundを1で初期化する', async () => {
+      const book = await service.createBook('user-123', input);
+
+      expect(book.round).toBe(1);
+    });
+
+    it('createdAt/updatedAtを設定する', async () => {
+      const book = await service.createBook('user-123', input);
+
+      expect(book.createdAt).toBe('2024-01-01T00:00:00.000Z');
+      expect(book.updatedAt).toBe('2024-01-01T00:00:00.000Z');
+    });
+
+    it('skillsが未指定の場合は空配列', async () => {
+      const book = await service.createBook('user-123', {
+        title: 'テスト本',
+        totalPages: 100,
+      });
+
+      expect(book.skills).toEqual([]);
+    });
+
+    it('入力値を正しく設定する', async () => {
+      const book = await service.createBook('user-123', {
+        title: 'テスト本',
+        isbn: '9784774183169',
+        totalPages: 350,
+        skills: ['DB', '設計'],
+      });
+
+      expect(book.title).toBe('テスト本');
+      expect(book.isbn).toBe('9784774183169');
+      expect(book.totalPages).toBe(350);
+      expect(book.skills).toEqual(['DB', '設計']);
+      expect(book.userId).toBe('user-123');
+    });
+
+    it('リポジトリのsaveを呼び出す', async () => {
+      await service.createBook('user-123', input);
+
+      expect(mockSave).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('listBooks', () => {
+    it('リポジトリから取得した本を返す', async () => {
+      const mockBooks: Book[] = [
+        {
+          id: 'book-1',
+          userId: 'user-123',
+          title: '本1',
+          totalPages: 100,
+          currentPage: 0,
+          status: 'reading',
+          skills: [],
+          round: 1,
+          createdAt: '2024-01-01T00:00:00Z',
+          updatedAt: '2024-01-01T00:00:00Z',
+        },
+      ];
+      mockFindByUserId.mockResolvedValueOnce(mockBooks);
+
+      const result = await service.listBooks('user-123');
+
+      expect(mockFindByUserId).toHaveBeenCalledWith('user-123');
+      expect(result).toEqual(mockBooks);
+    });
+  });
+
+  describe('getBook', () => {
+    it('存在する本を返す', async () => {
+      const mockBook: Book = {
+        id: 'book-123',
+        userId: 'user-123',
+        title: 'テスト本',
+        totalPages: 100,
+        currentPage: 0,
+        status: 'reading',
+        skills: [],
+        round: 1,
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+      };
+      mockFindById.mockResolvedValueOnce(mockBook);
+
+      const result = await service.getBook('user-123', 'book-123');
+
+      expect(mockFindById).toHaveBeenCalledWith('user-123', 'book-123');
+      expect(result).toEqual(mockBook);
+    });
+
+    it('存在しない本はnullを返す', async () => {
+      mockFindById.mockResolvedValueOnce(null);
+
+      const result = await service.getBook('user-123', 'not-exist');
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/apps/api/src/services/bookService.ts
+++ b/apps/api/src/services/bookService.ts
@@ -1,0 +1,40 @@
+import { nanoid } from 'nanoid';
+import type { Book } from '@tsundoku-dragon/shared';
+import { BookRepository } from '../repositories/bookRepository';
+import type { CreateBookInput } from '../types/api';
+import type { Env } from '../lib/dynamodb';
+
+export class BookService {
+  private repository: BookRepository;
+
+  constructor(env: Env) {
+    this.repository = new BookRepository(env);
+  }
+
+  async createBook(userId: string, input: CreateBookInput): Promise<Book> {
+    const now = new Date().toISOString();
+    const book: Book = {
+      id: nanoid(),
+      userId,
+      title: input.title,
+      isbn: input.isbn,
+      totalPages: input.totalPages,
+      currentPage: 0,
+      status: 'reading',
+      skills: input.skills ?? [],
+      round: 1,
+      createdAt: now,
+      updatedAt: now,
+    };
+    await this.repository.save(book);
+    return book;
+  }
+
+  async listBooks(userId: string): Promise<Book[]> {
+    return this.repository.findByUserId(userId);
+  }
+
+  async getBook(userId: string, bookId: string): Promise<Book | null> {
+    return this.repository.findById(userId, bookId);
+  }
+}

--- a/apps/api/src/types/api.ts
+++ b/apps/api/src/types/api.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const createBookSchema = z.object({
+  title: z.string().min(1, 'タイトルは必須です'),
+  isbn: z.string().optional(),
+  totalPages: z.number().int().positive('ページ数は1以上の整数です'),
+  skills: z.array(z.string()).optional(),
+});
+
+export type CreateBookInput = z.infer<typeof createBookSchema>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,12 +27,33 @@
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.962.0",
         "@aws-sdk/lib-dynamodb": "^3.962.0",
-        "hono": "^4.0.0"
+        "@hono/zod-validator": "^0.7.6",
+        "hono": "^4.0.0",
+        "nanoid": "^5.1.6",
+        "zod": "^4.3.4"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.0.0",
         "vitest": "^4.0.16",
         "wrangler": "^4.0.0"
+      }
+    },
+    "apps/api/node_modules/nanoid": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.6.tgz",
+      "integrity": "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
       }
     },
     "apps/web": {
@@ -2049,6 +2070,16 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hono/zod-validator": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/@hono/zod-validator/-/zod-validator-0.7.6.tgz",
+      "integrity": "sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "hono": ">=3.9.0",
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -7290,10 +7321,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
-      "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
-      "dev": true,
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.4.tgz",
+      "integrity": "sha512-Zw/uYiiyF6pUT1qmKbZziChgNPRu+ZRneAsMUDU6IwmXdWt5JwcUfy2bvLOCUtz5UniaN/Zx5aFttZYbYc7O/A==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"


### PR DESCRIPTION
## Summary

- 本（Book）の登録・取得APIを実装
- レイヤードアーキテクチャで構成（routes → services → repositories）
- zod + @hono/zod-validator でバリデーション
- 27件のテストを追加

### エンドポイント

| メソッド | パス | 説明 |
|----------|------|------|
| POST | /books | 本の登録 |
| GET | /books | 本の一覧取得 |
| GET | /books/:id | 本の詳細取得 |

### 認証

Firebase Auth未実装のため、`X-User-Id`ヘッダーで一時対応（未指定時は`dev-user-001`）

## Test plan

- [x] `npm run test` - 27テスト全てパス
- [x] `npm run typecheck` - 型チェックOK
- [x] `npm run lint` - リントOK
- [x] DynamoDB Local + wrangler devで動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)