### PR TITLE
feat: GitHub ActionsでDynamoDB Local統合テストを自動実行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,33 @@ jobs:
       - run: npm ci
       - name: Build
         run: npm run build
+
+  integration-test:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    services:
+      dynamodb:
+        image: amazon/dynamodb-local:latest
+        ports:
+          - 8000:8000
+        options: >-
+          --health-cmd "curl -s http://localhost:8000 > /dev/null"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 3
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      - name: Create test table
+        run: npx tsx scripts/create-table.ts --local --test
+        env:
+          AWS_ACCESS_KEY_ID: local
+          AWS_SECRET_ACCESS_KEY: local
+      - name: Run integration tests
+        run: npm run test:integration
+        env:
+          DYNAMODB_ENDPOINT: http://localhost:8000

--- a/.steering/20260110-CI-CD統合テスト自動実行/design.md
+++ b/.steering/20260110-CI-CD統合テスト自動実行/design.md
@@ -1,0 +1,110 @@
+# 設計書
+
+## 意思決定
+
+### 採用した設計
+
+GitHub Actions servicesを使用してDynamoDB Localコンテナを起動し、既存のテーブル作成スクリプトを再利用して統合テスト環境を構築する。
+
+### 代替案との比較
+
+| 案                      | メリット                               | デメリット                         | 採用 |
+| ----------------------- | -------------------------------------- | ---------------------------------- | ---- |
+| GitHub Actions services | 設定がシンプル、ヘルスチェック組み込み | GitHub Actions専用                 | ✓    |
+| docker-compose in CI    | ローカルと同じ設定を使用可能           | docker-compose起動のオーバーヘッド | -    |
+| Testcontainers          | コードでコンテナ制御可能               | 依存ライブラリ追加が必要           | -    |
+
+### 選定理由
+
+- GitHub Actions servicesはワークフロー内でサービスコンテナを宣言的に定義でき、ヘルスチェックも組み込みでサポート
+- 追加の依存ライブラリが不要
+- 既存のCI設定と整合性が良い
+
+## データフロー
+
+### 統合テスト実行フロー
+
+1. GitHub Actions servicesでDynamoDB Localコンテナ起動
+2. ヘルスチェックでサービス準備完了を確認
+3. Node.js環境セットアップ、npm ci実行
+4. `npx tsx scripts/create-table.ts --local --test`でテストテーブル作成
+5. `npm run test:integration`で統合テスト実行
+6. テスト結果をGitHub Actionsに報告
+
+## コンポーネント設計
+
+### 追加・変更するファイル
+
+| ファイル                   | 種別 | 責務                         |
+| -------------------------- | ---- | ---------------------------- |
+| `.github/workflows/ci.yml` | 変更 | integration-testジョブを追加 |
+
+### CIワークフロー設計
+
+#### integration-testジョブ
+
+**責務**: DynamoDB Localを起動し、統合テストを実行
+
+**設定内容**:
+
+```yaml
+integration-test:
+  name: Integration Tests
+  runs-on: ubuntu-latest
+  services:
+    dynamodb:
+      image: amazon/dynamodb-local:latest
+      ports:
+        - 8000:8000
+      options: >-
+        --health-cmd "curl -f http://localhost:8000/ || exit 1"
+        --health-interval 10s
+        --health-timeout 5s
+        --health-retries 5
+  steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '22'
+        cache: 'npm'
+    - run: npm ci
+    - name: Create test table
+      run: npx tsx scripts/create-table.ts --local --test
+      env:
+        AWS_ACCESS_KEY_ID: local
+        AWS_SECRET_ACCESS_KEY: local
+    - name: Run integration tests
+      run: npm run test:integration
+      env:
+        DYNAMODB_ENDPOINT: http://localhost:8000
+```
+
+## テスト戦略
+
+### 検証方法
+
+- PRを作成して統合テストジョブが実行されることを確認
+- 3回連続でPRを更新し、テストが安定して成功することを確認
+
+### 失敗時の挙動
+
+- 統合テストが失敗した場合、ジョブ全体が失敗となりPRマージがブロックされる
+
+---
+
+## 任意セクション
+
+### ヘルスチェック設計
+
+DynamoDB Localのヘルスチェックには`curl`コマンドを使用:
+
+- `curl -f http://localhost:8000/`はDynamoDB Localが起動していれば400エラーを返す（認証なしリクエストのため）
+- ただし`curl -f`はHTTP 400を失敗として扱うため、代わりに`|| exit 1`で接続自体の失敗のみを検出
+
+**注意**: DynamoDB Localはルートパスへのリクエストに対して400を返すが、これはサービスが起動している証拠。ヘルスチェックコマンドを調整する必要がある可能性あり。
+
+### パフォーマンス考慮事項
+
+- `npm ci`のキャッシュを有効化してインストール時間を短縮
+- 統合テストは並列実行せず、データの競合を避ける
+- 2分以内の実行時間を目標とする

--- a/.steering/20260110-CI-CD統合テスト自動実行/requirements.md
+++ b/.steering/20260110-CI-CD統合テスト自動実行/requirements.md
@@ -1,0 +1,49 @@
+# CI/CDでの統合テスト自動実行
+
+## 概要
+
+GitHub ActionsでDynamoDB Localを起動し、統合テストを自動実行することでPR時の品質を担保する。
+
+## 背景
+
+- Issue #21（統合テスト環境の構築）、Issue #22（BookRepositoryの統合テスト実装）が完了済み
+- ローカルでは統合テストが実行可能だが、CI環境での自動実行が未設定
+- PRマージ前に統合テストを自動実行することで、データベース連携部分の品質を担保したい
+
+## 要件
+
+### 機能要件
+
+- [ ] `.github/workflows/ci.yml`に`integration-test`ジョブを追加
+- [ ] GitHub Actions servicesでDynamoDB Localを起動
+  - ヘルスチェック設定
+  - ポート8000でサービス公開
+- [ ] テーブル作成の自動化
+  - `npx tsx scripts/create-table.ts --local --test`実行
+  - 環境変数設定（AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY）
+- [ ] CI環境での統合テスト実行
+  - DYNAMODB_ENDPOINT=http://localhost:8000設定
+  - `npm run test:integration`実行
+
+### 非機能要件
+
+- 実行時間が2分以内
+- フレイキーなテストがない（安定して成功する）
+
+## 受け入れ条件
+
+- [ ] PR作成時に統合テストが自動実行される
+- [ ] 統合テストが失敗したらマージがブロックされる
+- [ ] 実行時間が2分以内
+- [ ] 3回連続で成功する（フレイキーでない）
+
+## 対象外（スコープ外）
+
+- E2Eテストの追加
+- 本番環境へのデプロイ自動化
+- テストカバレッジの計測
+
+## 参考ドキュメント
+
+- [docs/integration-testing.md](../../docs/integration-testing.md)
+- [GitHub Issue #23](https://github.com/dznbk/tsundoku-dragon/issues/23)

--- a/.steering/20260110-CI-CD統合テスト自動実行/tasklist.md
+++ b/.steering/20260110-CI-CD統合テスト自動実行/tasklist.md
@@ -1,0 +1,78 @@
+# タスクリスト
+
+## タスク完了の原則
+
+**このファイルの全タスクが完了するまで作業を継続すること**
+
+### 必須ルール
+
+- 全てのタスクを `[x]` にすること
+- 未完了タスク `[ ]` を残したまま作業を終了しない
+- 「時間の都合」「難しい」などの理由でのスキップは禁止
+
+### スキップが許可されるケース
+
+技術的理由に該当する場合のみ:
+
+- 実装方針の変更により機能自体が不要になった
+- アーキテクチャ変更により別の実装方法に置き換わった
+
+スキップ時は理由を明記:
+
+```markdown
+- [~] タスク名 (スキップ理由: 具体的な技術的理由)
+```
+
+---
+
+## 進捗
+
+- 開始: 2026-01-10
+- 完了: 2026-01-10
+
+---
+
+## フェーズ1: CI設定の追加
+
+- [x] `.github/workflows/ci.yml`に`integration-test`ジョブを追加
+  - DynamoDB Local servicesの定義
+  - ヘルスチェック設定
+  - ポート8000でサービス公開
+- [x] テーブル作成ステップを追加
+  - `npx tsx scripts/create-table.ts --local --test`実行
+  - 環境変数設定（AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY）
+- [x] 統合テスト実行ステップを追加
+  - DYNAMODB_ENDPOINT環境変数設定
+  - `npm run test:integration`実行
+
+## フェーズ2: 動作確認
+
+- [x] ローカルで既存のlint/test/buildジョブが壊れていないことを確認
+
+## フェーズ3: 品質チェック
+
+- [x] テストが通ることを確認 (`npm run test:all`)
+- [x] リントエラーがないことを確認 (`npm run lint`)
+- [x] 型エラーがないことを確認 (`npm run typecheck`)
+- [x] フォーマットエラーがないことを確認 (`npm run format:check`)
+
+---
+
+## 振り返り
+
+### うまくいったこと
+
+- GitHub Actions servicesを使用することで、シンプルな設定でDynamoDB Localをサービスコンテナとして起動できた
+- 既存のテーブル作成スクリプト（`create-table.ts`）を再利用でき、新規コードを最小限に抑えられた
+- 既存のCI設定（lint, test, build）と一貫したパターン（Node.js 22、actions/checkout@v4など）で実装できた
+
+### 改善点
+
+- 初期のヘルスチェック設定が`|| exit 0`で常に成功する状態だった（レビューで指摘、修正済み）
+- ヘルスチェックのinterval/timeout/retriesを初期設定より短縮できることに後から気づいた
+
+### 次回への学び
+
+- GitHub Actions servicesのヘルスチェックコマンドは、失敗時に適切にexit codeを返すよう注意が必要
+- DynamoDB Localは起動が速いため、ヘルスチェックの間隔は短くても問題ない（5s interval, 3s timeout, 3 retriesで十分）
+- `curl -s URL > /dev/null`パターンは、接続確認のシンプルなヘルスチェックとして有効


### PR DESCRIPTION
## Summary

- GitHub Actions CIに `integration-test` ジョブを追加
- GitHub Actions servicesでDynamoDB Localコンテナを自動起動
- PR作成時に統合テストが自動実行されるように設定

## Changes

- `.github/workflows/ci.yml` に統合テストジョブを追加
  - DynamoDB Local serviceの定義（ポート8000）
  - ヘルスチェック設定（5s間隔、3回リトライ）
  - テーブル作成の自動実行
  - 統合テスト実行

## Test plan

- [ ] このPRでCIが実行され、integration-testジョブが成功することを確認
- [ ] 統合テストが正常に実行されることを確認

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)