### PR TITLE
feat: Claude Code on the Web用のgh CLIセットアップフックを追加

### DIFF
--- a/.claude/hooks/gh-setup.sh
+++ b/.claude/hooks/gh-setup.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# This is sample script, and you should verify your own.
+# SessionStart hook: GitHub CLI auto-installation for remote environments
+# This script installs gh CLI when running in Claude Code on the Web
+# following best practices: idempotent, fail-safe, proper logging
+
+set -e
+
+LOG_PREFIX="[gh-setup]"
+
+log() {
+    echo "$LOG_PREFIX $1" >&2
+}
+
+# Only run in remote Claude Code environment
+if [ "$CLAUDE_CODE_REMOTE" != "true" ]; then
+    log "Not a remote session, skipping gh setup"
+    exit 0
+fi
+
+log "Remote session detected, checking gh CLI..."
+
+# Check if gh is already available
+if command -v gh &>/dev/null; then
+    log "gh CLI already available: $(gh --version | head -1)"
+    exit 0
+fi
+
+# Setup local bin directory
+LOCAL_BIN="$HOME/.local/bin"
+mkdir -p "$LOCAL_BIN"
+
+# Check if gh exists in local bin
+if [ -x "$LOCAL_BIN/gh" ]; then
+    log "gh found in $LOCAL_BIN"
+    # Ensure PATH includes local bin
+    if [[ ":$PATH:" != *":$LOCAL_BIN:"* ]]; then
+        export PATH="$LOCAL_BIN:$PATH"
+        # Persist to CLAUDE_ENV_FILE if available
+        if [ -n "$CLAUDE_ENV_FILE" ]; then
+            echo "export PATH=\"$LOCAL_BIN:\$PATH\"" >> "$CLAUDE_ENV_FILE"
+            log "PATH updated in CLAUDE_ENV_FILE"
+        fi
+    fi
+    exit 0
+fi
+
+log "Installing gh CLI to $LOCAL_BIN..."
+
+# Create temp directory for installation
+TEMP_DIR=$(mktemp -d)
+trap "rm -rf $TEMP_DIR" EXIT
+
+# Detect architecture
+ARCH=$(uname -m)
+case "$ARCH" in
+    x86_64)
+        GH_ARCH="amd64"
+        ;;
+    aarch64|arm64)
+        GH_ARCH="arm64"
+        ;;
+    *)
+        log "Unsupported architecture: $ARCH"
+        exit 0  # Fail-safe: exit 0 even on failure
+        ;;
+esac
+
+# Download and install gh CLI
+GH_VERSION="2.62.0"
+GH_TARBALL="gh_${GH_VERSION}_linux_${GH_ARCH}.tar.gz"
+GH_URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/${GH_TARBALL}"
+
+log "Downloading gh v${GH_VERSION} for ${GH_ARCH}..."
+
+if ! curl -sL "$GH_URL" -o "$TEMP_DIR/$GH_TARBALL"; then
+    log "Failed to download gh CLI"
+    exit 0  # Fail-safe
+fi
+
+log "Extracting..."
+if ! tar -xzf "$TEMP_DIR/$GH_TARBALL" -C "$TEMP_DIR"; then
+    log "Failed to extract gh CLI"
+    exit 0  # Fail-safe
+fi
+
+# Move binary to local bin
+if ! mv "$TEMP_DIR/gh_${GH_VERSION}_linux_${GH_ARCH}/bin/gh" "$LOCAL_BIN/gh"; then
+    log "Failed to install gh CLI"
+    exit 0  # Fail-safe
+fi
+
+chmod +x "$LOCAL_BIN/gh"
+
+# Update PATH
+export PATH="$LOCAL_BIN:$PATH"
+
+# Persist PATH to CLAUDE_ENV_FILE if available
+if [ -n "$CLAUDE_ENV_FILE" ]; then
+    echo "export PATH=\"$LOCAL_BIN:\$PATH\"" >> "$CLAUDE_ENV_FILE"
+    log "PATH persisted to CLAUDE_ENV_FILE"
+fi
+
+log "gh CLI installed successfully: $($LOCAL_BIN/gh --version | head -1)"
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./.claude/hooks/gh-setup.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Claude Code on the Webのリモート環境でセッション開始時にgh CLIを自動インストールするフックを追加
- `CLAUDE_CODE_REMOTE=true` の環境でのみ動作し、既にインストール済みの場合はスキップ
- fail-safe設計により、エラー時もセッション開始をブロックしない

## Test plan
- [ ] Claude Code on the Webでリポジトリを開き、gh CLIが自動インストールされることを確認
- [ ] ローカル環境では何も実行されないことを確認（`CLAUDE_CODE_REMOTE`未設定時）
- [ ] 2回目以降のセッションでインストール済みとしてスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)