### PR TITLE
feat: 開発タスク管理用のTaskfileを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,19 +25,27 @@
 | [docs/glossary.md](docs/glossary.md)                             | 用語集                     |
 | [docs/CONTEXT.md](docs/CONTEXT.md)                               | 開発コンテキスト・議論ログ |
 
-## よく使うコマンド
+## Taskfile
+
+プロジェクトルートの `Taskfile` で開発タスクを実行する。
 
 ```bash
-# 開発サーバー
-npm run dev              # ルートから全体起動
-cd apps/web && npm run dev   # フロントのみ
-cd apps/api && npm run dev   # APIのみ
-
-# テスト・検証
-npm run test             # テスト実行
-npm run typecheck        # 型チェック
-npm run lint             # リント
+./Taskfile setup            # 初期セットアップ（npm install、.envコピー）
+./Taskfile dev              # 全サービス起動（DB + api + web）
+./Taskfile check            # CI相当のローカルチェック（push前に実行）
+./Taskfile test             # ユニットテスト
+./Taskfile test:integration # 統合テスト
+./Taskfile test:all         # 全テスト
+./Taskfile db:start         # DynamoDB Local 起動
+./Taskfile db:stop          # DynamoDB Local 停止
 ```
+
+**使う場面:**
+
+- 新規開発者の環境構築 → `./Taskfile setup`
+- 日常の開発 → `./Taskfile dev`
+- コミット/プッシュ前の確認 → `./Taskfile check`
+- 統合テスト実行前 → `./Taskfile test:setup`
 
 ## 重要なルール
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ asdfを使っている場合は `.tool-versions` で自動的にバージョン�
 git clone https://github.com/your-username/tsundoku-dragon.git
 cd tsundoku-dragon
 
-# 依存関係のインストール
-npm install
+# 初期セットアップ（依存関係インストール + .env作成）
+./Taskfile setup
 ```
 
 ## 開発
@@ -43,7 +43,11 @@ http://localhost:8787 で起動します。
 
 ### 両方同時に起動
 
-ターミナルを2つ開いて、それぞれで `npm run dev:web` と `npm run dev:api` を実行してください。
+```bash
+./Taskfile dev
+```
+
+DynamoDB Local + API + Web を同時に起動します。Ctrl+C で全て停止します。
 
 ## その他のコマンド
 

--- a/Taskfile
+++ b/Taskfile
@@ -1,0 +1,72 @@
+#!/bin/bash
+PATH=./node_modules/.bin:$PATH
+
+function setup {
+    echo "==> Installing dependencies..."
+    npm install
+
+    # .env ファイルのコピー（存在しなければ）
+    if [ ! -f apps/web/.env ]; then
+        echo "==> Copying .env.example to .env (apps/web)"
+        cp apps/web/.env.example apps/web/.env
+        echo "    Please edit apps/web/.env with your Firebase credentials"
+    fi
+
+    # ツール確認
+    echo "==> Environment check:"
+    echo "    Node: $(node -v)"
+    echo "    npm: $(npm -v)"
+    echo "    Docker: $(docker -v 2>/dev/null || echo 'not found')"
+}
+
+function dev {
+    # DB起動 → api + web を並列起動
+    db:start
+    trap 'db:stop' EXIT  # 終了時にDB停止
+    npm run dev:api & npm run dev:web & wait
+}
+
+function test:setup {
+    ./scripts/setup-integration-tests.sh
+}
+
+function test {
+    npm test
+}
+
+function test:integration {
+    npm run test:integration
+}
+
+function test:all {
+    npm run test:all
+}
+
+function check {
+    npm run format:check && npm run lint && npm run typecheck && npm test
+}
+
+function db:start {
+    docker compose up -d dynamodb-local
+}
+
+function db:stop {
+    docker compose down
+}
+
+function default {
+    echo "Usage: ./Taskfile <task>"
+    echo ""
+    echo "Tasks:"
+    echo "  setup            Initial setup (npm install, .env copy, tool check)"
+    echo "  dev              Start all services (DB + api + web)"
+    echo "  test:setup       Setup test environment"
+    echo "  test             Run unit tests"
+    echo "  test:integration Run integration tests"
+    echo "  test:all         Run all tests"
+    echo "  check            Run CI checks locally (format, lint, typecheck, test)"
+    echo "  db:start         Start DynamoDB Local"
+    echo "  db:stop          Stop DynamoDB Local"
+}
+
+"${@:-default}"


### PR DESCRIPTION
## Summary

- bashベースのTaskfileを追加し、開発ワークフローを簡略化
- `./Taskfile dev` で DB + api + web を1コマンドで同時起動可能に
- `./Taskfile check` でCI相当のローカルチェック（push前に便利）
- CLAUDE.md / README.md にTaskfileの使い方を記載

## 利用可能なタスク

| タスク | 内容 |
|--------|------|
| `setup` | 初期セットアップ（npm install、.envコピー） |
| `dev` | 全サービス起動（DB + api + web） |
| `check` | CI相当のローカルチェック |
| `test` / `test:integration` / `test:all` | テスト実行 |
| `db:start` / `db:stop` | DynamoDB Local 操作 |

## Test plan

- [ ] `./Taskfile` でヘルプが表示される
- [ ] `./Taskfile setup` で初期セットアップが動作する
- [ ] `./Taskfile dev` でDB + api + webが起動し、Ctrl+Cで全停止する
- [ ] `./Taskfile check` でlint + typecheck + testが実行される

🤖 Generated with [Claude Code](https://claude.com/claude-code)