### PR TITLE
docs: ステージング・本番環境の構築計画を追加

### DIFF
--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -83,10 +83,13 @@
 - Googleログインブランディング（GoogleLoginButton、Googleロゴ）
 - continue-featureコマンド（フィードバック対応ワークフロー）
 - タイトル検索機能（TitleSearchInput、NDL API、useTitleSearch）
+- ホーム画面（本一覧）（BookGrid、BookCard、ProgressBar、UserStatus、CompletedToggle、BottomActionBar）
 
 ### 次にやること
 
-1. ホーム画面（本一覧）
+1. ステージング・本番環境の構築
+   - 計画: [planning/deployment-plan.md](../planning/deployment-plan.md)
+2. 本の詳細画面
 
 ### スキップ
 
@@ -148,6 +151,40 @@
 ---
 
 ## 議論ログ
+
+### 2026-01-14 ステージング・本番環境の構築計画
+
+**議論した内容：**
+
+- 次にやることの優先順位（機能実装 vs インフラ整備）
+- デプロイ環境の構成（staging / production）
+- Webホスティング先（Cloudflare Pages）
+- CDトリガー（staging: main push自動、production: 手動/タグ）
+- カスタムドメイン設計（deepon.dev を使用）
+
+**決定事項：**
+
+| 決定                                                                   | 理由                                                          |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------- |
+| Cloudflare Pages (Direct Upload)                                       | APIがCloudflare Workersなので統一。GitHub Actionsから制御可能 |
+| staging: main push → 自動デプロイ                                      | 開発中の動作確認を迅速に                                      |
+| production: workflow_dispatch / タグ                                   | 本番リリースは明示的に制御                                    |
+| ドメイン: tsundoku.deepon.dev (prod), stg.tsundoku.deepon.dev (stg)    | 環境.サービス.ドメインの一般的パターン                        |
+| API: api.tsundoku.deepon.dev (prod), api-stg.tsundoku.deepon.dev (stg) | フロントと同じ命名規則                                        |
+
+**構成:**
+
+| レイヤー | staging                     | production              |
+| -------- | --------------------------- | ----------------------- |
+| Frontend | stg.tsundoku.deepon.dev     | tsundoku.deepon.dev     |
+| API      | api-stg.tsundoku.deepon.dev | api.tsundoku.deepon.dev |
+| DB       | tsundoku-dragon-staging     | tsundoku-dragon-prod    |
+
+**計画ファイル:**
+
+- [planning/deployment-plan.md](../planning/deployment-plan.md)
+
+---
 
 ### 2026-01-11 タイトル検索機能
 

--- a/planning/deployment-plan.md
+++ b/planning/deployment-plan.md
@@ -1,0 +1,165 @@
+# ステージング・本番環境の構築計画
+
+## 概要
+
+積読＆ドラゴンズのステージング環境と本番環境を構築する。
+
+## デプロイ戦略
+
+| 環境       | トリガー                                  | 用途             |
+| ---------- | ----------------------------------------- | ---------------- |
+| staging    | main ブランチへの push                    | 開発中の動作確認 |
+| production | workflow_dispatch（手動）または タグ push | 本番リリース     |
+
+## 構成
+
+| レイヤー | 技術                             | staging                             | production              |
+| -------- | -------------------------------- | ----------------------------------- | ----------------------- |
+| Frontend | Cloudflare Pages (Direct Upload) | stg.tsundoku.deepon.dev             | tsundoku.deepon.dev     |
+| API      | Cloudflare Workers               | api-stg.tsundoku.deepon.dev         | api.tsundoku.deepon.dev |
+| DB       | DynamoDB                         | tsundoku-dragon-staging             | tsundoku-dragon-prod    |
+| Auth     | Firebase                         | 同一プロジェクト（tsundoku-dragon） | 同一                    |
+
+---
+
+## タスクリスト
+
+### Phase 1: AWSリソース作成（手動）
+
+1. **DynamoDB テーブル作成**
+   - staging: `tsundoku-dragon-staging`
+   - production: `tsundoku-dragon-prod`
+   - リージョン: ap-northeast-1
+   - 課金モード: On-Demand（PAY_PER_REQUEST）
+
+2. **IAM ユーザー作成**
+   - 用途: Cloudflare Workers からの DynamoDB アクセス
+   - ポリシー: DynamoDB への読み書き権限のみ
+   - 環境別に分けるか、同一ユーザーで両テーブルへのアクセスを許可
+
+### Phase 2: Cloudflare リソース作成
+
+3. **KV Namespace 作成**
+
+   ```bash
+   cd apps/api
+   # staging
+   wrangler kv:namespace create PUBLIC_JWK_CACHE_KV --env staging
+   # production
+   wrangler kv:namespace create PUBLIC_JWK_CACHE_KV
+   ```
+
+4. **wrangler.toml 環境別設定化**
+   - ファイル: [apps/api/wrangler.toml](apps/api/wrangler.toml)
+   - `[env.staging]` と `[env.production]` セクション追加
+   - 各環境の DynamoDB テーブル名、KV Namespace ID を設定
+
+5. **Cloudflare Secrets 設定**
+   ```bash
+   # staging
+   wrangler secret put AWS_ACCESS_KEY_ID --env staging
+   wrangler secret put AWS_SECRET_ACCESS_KEY --env staging
+   # production
+   wrangler secret put AWS_ACCESS_KEY_ID
+   wrangler secret put AWS_SECRET_ACCESS_KEY
+   ```
+
+### Phase 3: Cloudflare Pages 設定
+
+6. **Cloudflare Pages プロジェクト作成**
+   - Cloudflare Dashboard から Direct Upload プロジェクトとして作成
+   - GitHub 連携は使わない（GitHub Actions から Direct Upload する）
+   - プロジェクト名: `tsundoku-dragon`
+
+7. **GitHub Actions 用の API トークン取得**
+   - Cloudflare Dashboard → My Profile → API Tokens
+   - 「Edit Cloudflare Workers」テンプレートをベースに作成
+   - Pages の編集権限を追加
+   - GitHub Secrets に `CLOUDFLARE_API_TOKEN` として登録
+
+### Phase 4: CD ワークフロー作成
+
+8. **deploy.yml 作成**
+   - ファイル: `.github/workflows/deploy.yml`
+   - トリガー:
+     - `push` to main → staging 自動デプロイ
+     - `workflow_dispatch` → 環境選択パラメータで staging/production
+     - `push` tags `v*` → production 自動デプロイ（オプション）
+   - ジョブ:
+     - Web ビルド（npm run build）
+     - Web デプロイ（wrangler pages deploy apps/web/dist）
+     - API デプロイ（wrangler deploy）
+   - 環境変数の注入:
+     - staging: `VITE_API_URL=https://api-stg.tsundoku.deepon.dev`
+     - production: `VITE_API_URL=https://api.tsundoku.deepon.dev`
+
+### Phase 5: カスタムドメイン設定
+
+9. **Cloudflare DNS 設定**
+   - deepon.dev のゾーンに以下の CNAME レコードを追加:
+     - `tsundoku` → `tsundoku-dragon.pages.dev`（本番 Web）
+     - `stg.tsundoku` → `tsundoku-dragon.pages.dev`（staging Web）
+     - `api.tsundoku` → `tsundoku-dragon.<account>.workers.dev`（本番 API）
+     - `api-stg.tsundoku` → `tsundoku-dragon-staging.<account>.workers.dev`（staging API）
+
+10. **Workers カスタムドメイン設定**
+    - wrangler.toml の routes または Cloudflare Dashboard から設定
+
+11. **Pages カスタムドメイン設定**
+    - Cloudflare Dashboard → Pages → tsundoku-dragon → Custom domains
+    - 本番: tsundoku.deepon.dev
+    - staging: stg.tsundoku.deepon.dev
+
+### Phase 6: ドキュメント更新
+
+12. **CONTEXT.md 更新**
+    - 「次にやること」をステージング環境構築に変更
+    - 完了後は「本の詳細画面」に更新
+
+13. **CLAUDE.md 更新（必要に応じて）**
+    - デプロイ手順の詳細化
+
+---
+
+## 修正対象ファイル
+
+| ファイル                                         | 変更内容         |
+| ------------------------------------------------ | ---------------- |
+| [apps/api/wrangler.toml](apps/api/wrangler.toml) | 環境別設定追加   |
+| `.github/workflows/deploy.yml`                   | 新規作成         |
+| [docs/CONTEXT.md](docs/CONTEXT.md)               | 次にやること更新 |
+
+---
+
+## 検証方法
+
+1. **staging 環境デプロイ**
+   - main ブランチに push（自動）または workflow_dispatch で staging を選択
+   - API: `https://api-stg.tsundoku.deepon.dev/health` にアクセス
+   - Web: `https://stg.tsundoku.deepon.dev` にアクセス
+
+2. **E2E 動作確認**
+   - ログイン（Firebase Auth）
+   - 本の登録（NDL API 連携含む）
+   - 本一覧表示
+
+3. **本番環境デプロイ**
+   - workflow_dispatch で production を選択
+   - または `v1.0.0` のようなタグを push
+   - API: `https://api.tsundoku.deepon.dev/health`
+   - Web: `https://tsundoku.deepon.dev`
+
+---
+
+## 注意事項
+
+- Firebase Auth は同一プロジェクトを使用（環境分離しない）
+- DynamoDB テーブルは環境別に分離（データの混在を防ぐ）
+- Direct Upload 方式のため、PR Preview は自動生成されない
+  - 必要なら workflow_dispatch で staging にデプロイして確認
+
+## 今後の拡張（スコープ外）
+
+- Terraform による IaC 化
+- Monitoring / Alerting
+- PR Preview 自動デプロイ


### PR DESCRIPTION
## Summary
- ステージング・本番環境の構築計画ドキュメントを追加
- CONTEXT.md を更新（ホーム画面完了、次タスク更新、議論ログ追記）

## 変更内容

### planning/deployment-plan.md（新規）
- staging / production の2環境構成
- Cloudflare Pages (Direct Upload) + Workers
- カスタムドメイン: tsundoku.deepon.dev, stg.tsundoku.deepon.dev
- デプロイトリガー: staging = main push、production = 手動/タグ

### docs/CONTEXT.md
- 完了: ホーム画面（本一覧）
- 次にやること: ステージング環境構築 → 本の詳細画面
- 議論ログ: 2026-01-14 ステージング・本番環境の構築計画

## Test plan
- [ ] ドキュメントのリンクが正しく機能すること
- [ ] マークダウンのフォーマットが正しいこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)