### PR TITLE
fix: Firebase 環境変数をビルド時に設定

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,12 @@ jobs:
         run: npm run build -w apps/web
         env:
           VITE_API_URL: https://api-stg.tsundoku.deepon.dev
+          VITE_FIREBASE_API_KEY: AIzaSyCbKl_Y1WRDbhcV7Kj3S9QjE7_MhmvPaQI
+          VITE_FIREBASE_AUTH_DOMAIN: tsundoku-dragon.firebaseapp.com
+          VITE_FIREBASE_PROJECT_ID: tsundoku-dragon
+          VITE_FIREBASE_STORAGE_BUCKET: tsundoku-dragon.firebasestorage.app
+          VITE_FIREBASE_MESSAGING_SENDER_ID: '80428827990'
+          VITE_FIREBASE_APP_ID: '1:80428827990:web:0d971fc7b060d1732e82f7'
 
       - name: Deploy Web to Cloudflare Workers
         uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1


### PR DESCRIPTION
## Summary
- deploy.yml に Firebase 環境変数を追加
- ビルド時に VITE_FIREBASE_* が設定されるように修正

## 原因
staging 環境でフロントエンドが動作しなかった原因：
Firebase 環境変数がビルド時に渡されていなかった

## Test plan
- [ ] マージ後、https://stg.tsundoku.deepon.dev/ でログイン画面が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)