### PR TITLE
refactor: CORS origin を環境変数で制御

### DIFF
--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import app from './index';
 
+const mockEnv = {
+  ALLOWED_ORIGINS: 'http://localhost:5173',
+};
+
 describe('API', () => {
   it('responds to health check', async () => {
-    const res = await app.request('/health');
+    const res = await app.request('/health', {}, mockEnv);
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json).toEqual({ status: 'ok' });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -10,19 +10,18 @@ import skills from './routes/skills';
 const app = new Hono<{ Bindings: Env }>();
 
 // CORS設定（OPTIONSプリフライトリクエストを許可）
-app.use(
-  '*',
-  cors({
-    origin: [
-      'http://localhost:5173',
-      'http://localhost:4173',
-      'https://stg.tsundoku.deepon.dev',
-      'https://tsundoku.deepon.dev',
-    ],
+// 許可するoriginは環境変数で制御（カンマ区切り）
+app.use('*', async (c, next) => {
+  const allowedOrigins = c.env.ALLOWED_ORIGINS?.split(',') ?? [
+    'http://localhost:5173',
+  ];
+  const corsMiddleware = cors({
+    origin: allowedOrigins,
     allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
     allowHeaders: ['Content-Type', 'Authorization'],
-  })
-);
+  });
+  return corsMiddleware(c, next);
+});
 
 // 認証が必要なルートにミドルウェアを適用
 app.use('/books', authMiddleware);

--- a/apps/api/src/types/env.ts
+++ b/apps/api/src/types/env.ts
@@ -13,4 +13,6 @@ export type Env = {
   PUBLIC_JWK_CACHE_KEY: string;
   PUBLIC_JWK_CACHE_KV: KVNamespace;
   FIREBASE_AUTH_EMULATOR_HOST?: string;
+  // CORS
+  ALLOWED_ORIGINS?: string;
 };

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -26,6 +26,7 @@ AWS_REGION = "ap-northeast-1"
 FIREBASE_PROJECT_ID = "tsundoku-dragon"
 PUBLIC_JWK_CACHE_KEY = "firebase-public-jwk-cache-key"
 DYNAMODB_TABLE_NAME = "tsundoku-dragon-staging"
+ALLOWED_ORIGINS = "https://stg.tsundoku.deepon.dev"
 
 [[env.staging.kv_namespaces]]
 binding = "PUBLIC_JWK_CACHE_KV"
@@ -39,6 +40,7 @@ id = "486c84b66f0842e798c973b5ea081976"
 #
 # [env.production.vars]
 # DYNAMODB_TABLE_NAME = "tsundoku-dragon-prod"
+# ALLOWED_ORIGINS = "https://tsundoku.deepon.dev"
 #
 # [[env.production.kv_namespaces]]
 # binding = "PUBLIC_JWK_CACHE_KV"


### PR DESCRIPTION
## Summary
- CORS の許可 origin を環境変数 `ALLOWED_ORIGINS` で制御するように変更
- 環境ごとに許可する origin を分離し、セキュリティを向上

## 変更内容
- staging API: `stg.tsundoku.deepon.dev` のみ許可
- production API: `tsundoku.deepon.dev` のみ許可（コメントで準備）
- ローカル開発: `localhost:5173`（デフォルト）

## 背景
以前の実装では全ての環境（localhost, staging, production）が1つの配列にハードコードされており、
本番フロントから staging API へのリクエストも許可されてしまう状態でした。

## Test plan
- [ ] `npm run test` が通ること
- [ ] マージ後、staging 環境で API 呼び出しが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)