### PR TITLE
refactor: eslint-disable コメントを削除

### DIFF
--- a/apps/api/src/repositories/bookRepository.ts
+++ b/apps/api/src/repositories/bookRepository.ts
@@ -78,8 +78,7 @@ export class BookRepository {
   }
 
   private toBook(item: Record<string, unknown>): Book {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { PK, SK, ...book } = item;
+    const { PK: _PK, SK: _SK, ...book } = item;
     return book as unknown as Book;
   }
 
@@ -87,8 +86,7 @@ export class BookRepository {
     item: Record<string, unknown>,
     bookId: string
   ): BattleLog {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { PK, SK, ...log } = item;
+    const { PK: _PK, SK: _SK, ...log } = item;
     return {
       ...log,
       bookId,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,7 +11,7 @@ export default tseslint.config(
     rules: {
       '@typescript-eslint/no-unused-vars': [
         'error',
-        { argsIgnorePattern: '^_' },
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
       ],
     },
   }


### PR DESCRIPTION
## Summary
- `eslint-disable-next-line @typescript-eslint/no-unused-vars` コメントを削除
- 代わりに `_PK`, `_SK` のようなアンダースコアプレフィックス変数を使用
- eslint設定に `varsIgnorePattern: '^_'` を追加して、`_` で始まる未使用変数を許可

## 変更内容
- `bookRepository.ts`: `toBook`, `toBattleLog` メソッドの変数リネーム
- `eslint.config.js`: `varsIgnorePattern` を追加

## 関連
PR #50 のレビューコメントへの対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)