### PR TITLE
feat: 経験値計算・スキル更新ロジックを実装 (#56)

### DIFF
--- a/apps/api/src/lib/expCalculator.test.ts
+++ b/apps/api/src/lib/expCalculator.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { expForLevel, levelFromExp, defeatBonus } from './expCalculator';
+
+describe('expCalculator', () => {
+  describe('expForLevel', () => {
+    it('expForLevel(1) = 50', () => {
+      expect(expForLevel(1)).toBe(50);
+    });
+
+    it('expForLevel(2) = 141 (floor(2^1.5 * 50))', () => {
+      // 2^1.5 = 2.828..., 2.828 * 50 = 141.42...
+      expect(expForLevel(2)).toBe(141);
+    });
+
+    it('expForLevel(10) = 1581 (floor(10^1.5 * 50))', () => {
+      // 10^1.5 = 31.622..., 31.622 * 50 = 1581.13...
+      expect(expForLevel(10)).toBe(1581);
+    });
+
+    it('expForLevel(0) = 0', () => {
+      expect(expForLevel(0)).toBe(0);
+    });
+
+    it('expForLevel(-1) = 0', () => {
+      expect(expForLevel(-1)).toBe(0);
+    });
+  });
+
+  describe('levelFromExp', () => {
+    it('levelFromExp(0) = 1', () => {
+      expect(levelFromExp(0)).toBe(1);
+    });
+
+    it('levelFromExp(49) = 1 (not enough for level 2)', () => {
+      expect(levelFromExp(49)).toBe(1);
+    });
+
+    it('levelFromExp(50) = 2 (exactly enough for level 2)', () => {
+      expect(levelFromExp(50)).toBe(2);
+    });
+
+    it('levelFromExp(51) = 2 (slightly over level 2 threshold)', () => {
+      expect(levelFromExp(51)).toBe(2);
+    });
+
+    it('levelFromExp(190) = 2 (not enough for level 3)', () => {
+      // 50 (lv1->2) + 141 (lv2->3) = 191
+      expect(levelFromExp(190)).toBe(2);
+    });
+
+    it('levelFromExp(191) = 3 (exactly enough for level 3)', () => {
+      expect(levelFromExp(191)).toBe(3);
+    });
+
+    it('negative exp returns level 1', () => {
+      expect(levelFromExp(-100)).toBe(1);
+    });
+  });
+
+  describe('defeatBonus', () => {
+    it('defeatBonus(350) = 35', () => {
+      expect(defeatBonus(350)).toBe(35);
+    });
+
+    it('defeatBonus(99) = 9', () => {
+      expect(defeatBonus(99)).toBe(9);
+    });
+
+    it('defeatBonus(100) = 10', () => {
+      expect(defeatBonus(100)).toBe(10);
+    });
+
+    it('defeatBonus(0) = 0', () => {
+      expect(defeatBonus(0)).toBe(0);
+    });
+
+    it('defeatBonus(-10) = 0', () => {
+      expect(defeatBonus(-10)).toBe(0);
+    });
+  });
+});

--- a/apps/api/src/lib/expCalculator.ts
+++ b/apps/api/src/lib/expCalculator.ts
@@ -1,0 +1,44 @@
+/**
+ * 経験値・レベル計算ユーティリティ
+ *
+ * 計算式: 必要経験値 = floor(Lv^1.5 × 50)
+ * レベル上限: 9999
+ */
+
+const MAX_LEVEL = 9999;
+
+/**
+ * 指定レベルから次のレベルに上がるのに必要な経験値
+ * 計算式: floor(Lv^1.5 × 50)
+ */
+export function expForLevel(level: number): number {
+  if (level < 1) return 0;
+  return Math.floor(Math.pow(level, 1.5) * 50);
+}
+
+/**
+ * 累計経験値からレベルを計算
+ * レベル1から開始し、経験値が足りなくなるまでレベルを上げる
+ */
+export function levelFromExp(totalExp: number): number {
+  if (totalExp < 0) return 1;
+
+  let level = 1;
+  let expNeeded = 0;
+
+  while (level < MAX_LEVEL) {
+    expNeeded += expForLevel(level);
+    if (totalExp < expNeeded) break;
+    level++;
+  }
+
+  return level;
+}
+
+/**
+ * 討伐ボーナスを計算（総ページ数の10%、端数切り捨て）
+ */
+export function defeatBonus(totalPages: number): number {
+  if (totalPages < 0) return 0;
+  return Math.floor(totalPages * 0.1);
+}

--- a/apps/api/src/repositories/skillRepository.integration.test.ts
+++ b/apps/api/src/repositories/skillRepository.integration.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { SkillRepository } from './skillRepository';
+import {
+  setupTestDB,
+  cleanupTestData,
+  createTestEnv,
+  resetClients,
+} from '../test-utils/dynamodb-helper';
+
+/**
+ * ユニークIDを生成
+ * テスト間の独立性を確保するため、各テストで一意のIDを使用
+ */
+const createUniqueId = (prefix: string): string =>
+  `${prefix}-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
+
+describe('SkillRepository Integration', () => {
+  let repository: SkillRepository;
+
+  beforeAll(async () => {
+    await setupTestDB();
+    const env = createTestEnv();
+    repository = new SkillRepository(env);
+  });
+
+  afterAll(async () => {
+    await cleanupTestData();
+    resetClients();
+  });
+
+  describe('upsertUserSkillExp', () => {
+    it('新規スキルの経験値レコードを作成できる', async () => {
+      const userId = createUniqueId('user');
+      const skillName = 'TypeScript';
+
+      const result = await repository.upsertUserSkillExp(userId, skillName, 50);
+
+      expect(result.name).toBe(skillName);
+      expect(result.exp).toBe(50);
+      expect(result.level).toBe(2); // 50exp = level 2
+
+      // 確認のため再取得
+      const stored = await repository.findUserSkillExp(userId, skillName);
+      expect(stored).not.toBeNull();
+      expect(stored?.exp).toBe(50);
+      expect(stored?.level).toBe(2);
+    });
+
+    it('既存スキルの経験値を加算できる', async () => {
+      const userId = createUniqueId('user');
+      const skillName = 'Go';
+
+      // 初回: 30exp
+      await repository.upsertUserSkillExp(userId, skillName, 30);
+
+      // 2回目: +50exp = 80exp
+      const result = await repository.upsertUserSkillExp(userId, skillName, 50);
+
+      expect(result.name).toBe(skillName);
+      expect(result.exp).toBe(80);
+      expect(result.level).toBe(2); // 80exp still level 2 (needs 191 for level 3)
+
+      // 確認のため再取得
+      const stored = await repository.findUserSkillExp(userId, skillName);
+      expect(stored?.exp).toBe(80);
+    });
+
+    it('経験値加算でレベルアップする', async () => {
+      const userId = createUniqueId('user');
+      const skillName = 'React';
+
+      // 初回: 100exp (level 2)
+      const first = await repository.upsertUserSkillExp(userId, skillName, 100);
+      expect(first.level).toBe(2);
+
+      // 2回目: +100exp = 200exp (level 3)
+      const second = await repository.upsertUserSkillExp(
+        userId,
+        skillName,
+        100
+      );
+      expect(second.exp).toBe(200);
+      expect(second.level).toBe(3); // 200exp > 191 = level 3
+    });
+
+    it('複数スキルを独立して更新できる', async () => {
+      const userId = createUniqueId('user');
+
+      await repository.upsertUserSkillExp(userId, 'Skill1', 100);
+      await repository.upsertUserSkillExp(userId, 'Skill2', 200);
+
+      const skill1 = await repository.findUserSkillExp(userId, 'Skill1');
+      const skill2 = await repository.findUserSkillExp(userId, 'Skill2');
+
+      expect(skill1?.exp).toBe(100);
+      expect(skill2?.exp).toBe(200);
+    });
+  });
+
+  describe('findUserSkillExp', () => {
+    it('存在しないスキルの場合はnullを返す', async () => {
+      const userId = createUniqueId('user');
+
+      const result = await repository.findUserSkillExp(
+        userId,
+        'NonExistentSkill'
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('存在するスキルの経験値を取得できる', async () => {
+      const userId = createUniqueId('user');
+      const skillName = 'Node.js';
+
+      await repository.upsertUserSkillExp(userId, skillName, 150);
+
+      const result = await repository.findUserSkillExp(userId, skillName);
+
+      expect(result).not.toBeNull();
+      expect(result?.name).toBe(skillName);
+      expect(result?.exp).toBe(150);
+    });
+  });
+});

--- a/apps/api/src/repositories/skillRepository.ts
+++ b/apps/api/src/repositories/skillRepository.ts
@@ -1,5 +1,11 @@
-import { GetCommand, PutCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import {
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+  UpdateCommand,
+} from '@aws-sdk/lib-dynamodb';
 import { createDynamoDBClient, type Env } from '../lib/dynamodb';
+import { levelFromExp } from '../lib/expCalculator';
 
 export interface GlobalSkill {
   name: string;
@@ -118,5 +124,81 @@ export class SkillRepository {
       exp: (item.exp as number) ?? 0,
       level: (item.level as number) ?? 1,
     }));
+  }
+
+  async findUserSkillExp(
+    userId: string,
+    skillName: string
+  ): Promise<UserSkillExp | null> {
+    const result = await this.client.send(
+      new GetCommand({
+        TableName: this.tableName,
+        Key: {
+          PK: `USER#${userId}`,
+          SK: `SKILL#${skillName}`,
+        },
+      })
+    );
+    if (!result.Item) {
+      return null;
+    }
+    return {
+      name: skillName,
+      exp: (result.Item.exp as number) ?? 0,
+      level: (result.Item.level as number) ?? 1,
+    };
+  }
+
+  async upsertUserSkillExp(
+    userId: string,
+    skillName: string,
+    expToAdd: number
+  ): Promise<UserSkillExp> {
+    // Use UpdateCommand with ADD to atomically add to exp
+    // if_not_exists creates the record if it doesn't exist
+    const result = await this.client.send(
+      new UpdateCommand({
+        TableName: this.tableName,
+        Key: {
+          PK: `USER#${userId}`,
+          SK: `SKILL#${skillName}`,
+        },
+        UpdateExpression:
+          'SET exp = if_not_exists(exp, :zero) + :expToAdd, updatedAt = :now',
+        ExpressionAttributeValues: {
+          ':zero': 0,
+          ':expToAdd': expToAdd,
+          ':now': new Date().toISOString(),
+        },
+        ReturnValues: 'ALL_NEW',
+      })
+    );
+
+    const newExp = (result.Attributes?.exp as number) ?? expToAdd;
+    const newLevel = levelFromExp(newExp);
+
+    // Update level in a separate call since it depends on newExp
+    await this.client.send(
+      new UpdateCommand({
+        TableName: this.tableName,
+        Key: {
+          PK: `USER#${userId}`,
+          SK: `SKILL#${skillName}`,
+        },
+        UpdateExpression: 'SET #level = :level',
+        ExpressionAttributeNames: {
+          '#level': 'level',
+        },
+        ExpressionAttributeValues: {
+          ':level': newLevel,
+        },
+      })
+    );
+
+    return {
+      name: skillName,
+      exp: newExp,
+      level: newLevel,
+    };
   }
 }


### PR DESCRIPTION
- expCalculator.ts: 経験値計算ユーティリティを追加
  - expForLevel: レベルに必要な経験値（floor(Lv^1.5 × 50)）
  - levelFromExp: 累計経験値からレベルを計算
  - defeatBonus: 討伐ボーナス（総ページ数の10%）
- SkillRepository: upsertUserSkillExp, findUserSkillExp メソッド追加
- BookService.recordBattle: 経験値計算と各スキルへの付与を追加
- RecordBattleResult: expGained, defeatBonus, skillResults フィールドを追加