### PR TITLE
feat: 本番環境の構築

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,47 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+categories:
+  - title: '🚀 New Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'chore'
+      - 'refactor'
+      - 'dependencies'
+  - title: '📝 Documentation'
+    labels:
+      - 'documentation'
+      - 'docs'
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&'
+
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+      - 'feature'
+  patch:
+    labels:
+      - 'patch'
+      - 'fix'
+      - 'bugfix'
+  default: patch
+
+template: |
+  ## Changes
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,54 @@
+name: Deploy Production
+
+on:
+  release:
+    types: [published]
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: true
+
+jobs:
+  deploy-production:
+    name: Deploy to Production
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Web
+        run: npm run build -w apps/web
+        env:
+          VITE_API_URL: https://api.tsundoku.deepon.dev
+          VITE_FIREBASE_API_KEY: AIzaSyCbKl_Y1WRDbhcV7Kj3S9QjE7_MhmvPaQI
+          VITE_FIREBASE_AUTH_DOMAIN: tsundoku-dragon.firebaseapp.com
+          VITE_FIREBASE_PROJECT_ID: tsundoku-dragon
+          VITE_FIREBASE_STORAGE_BUCKET: tsundoku-dragon.firebasestorage.app
+          VITE_FIREBASE_MESSAGING_SENDER_ID: '80428827990'
+          VITE_FIREBASE_APP_ID: '1:80428827990:web:0d971fc7b060d1732e82f7'
+
+      - name: Deploy Web to Cloudflare Workers
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: apps/web
+          command: deploy --env production
+
+      - name: Deploy API to Cloudflare Workers
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: apps/api
+          command: deploy --env production

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,23 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  update-release-draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -33,15 +33,18 @@ binding = "PUBLIC_JWK_CACHE_KV"
 id = "486c84b66f0842e798c973b5ea081976"
 
 # ============================================================
-# Production 環境（後で設定）
+# Production 環境
 # ============================================================
-# [env.production]
-# name = "tsundoku-dragon-api"
-#
-# [env.production.vars]
-# DYNAMODB_TABLE_NAME = "tsundoku-dragon-prod"
-# ALLOWED_ORIGINS = "https://tsundoku.deepon.dev"
-#
-# [[env.production.kv_namespaces]]
-# binding = "PUBLIC_JWK_CACHE_KV"
-# id = "REPLACE_ME_WITH_PRODUCTION_KV_ID"
+[env.production]
+name = "tsundoku-dragon-api"
+
+[env.production.vars]
+AWS_REGION = "ap-northeast-1"
+FIREBASE_PROJECT_ID = "tsundoku-dragon"
+PUBLIC_JWK_CACHE_KEY = "firebase-public-jwk-cache-key"
+DYNAMODB_TABLE_NAME = "tsundoku-dragon-prod"
+ALLOWED_ORIGINS = "https://tsundoku.deepon.dev"
+
+[[env.production.kv_namespaces]]
+binding = "PUBLIC_JWK_CACHE_KV"
+id = "1f79768d91be42e586b4c7d3a186e94e"

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -11,7 +11,7 @@ directory = "./dist"
 name = "tsundoku-dragon-staging"
 
 # ============================================================
-# Production 環境（後で設定）
+# Production 環境
 # ============================================================
-# [env.production]
-# name = "tsundoku-dragon"
+[env.production]
+name = "tsundoku-dragon"

--- a/planning/deployment-plan.md
+++ b/planning/deployment-plan.md
@@ -166,6 +166,15 @@
 - [ ] **Pages カスタムドメイン設定**
   - 本番: tsundoku.deepon.dev
 
+#### 追加-P: アクセス制限（一時的）
+
+- [ ] **Cloudflare Access 設定**
+  - Application: `tsundoku-dragon-production`
+  - 対象ホスト: `tsundoku.deepon.dev`（Web のみ、API は除外）
+  - 認証方式: One-time PIN（メール認証）
+  - ポリシー: 指定メールアドレスのみ許可
+  - ※動作確認完了後に解除
+
 #### Phase 6-P: 検証
 
 - [ ] **production 環境デプロイ & 動作確認**


### PR DESCRIPTION
## Summary

- wrangler.toml に production 環境設定を追加（API / Web）
- 本番デプロイ用ワークフロー (`deploy-production.yml`) を追加
  - release を publish した際に production へ自動デプロイ
- release-drafter を導入
  - main マージ時にリリースドラフトを自動更新
- deployment-plan.md に Cloudflare Access 設定項目を追記

## Test plan

- [x] 本番環境に手動デプロイして動作確認済み
  - API ヘルスチェック: `https://api.tsundoku.deepon.dev/health`
  - Web: `https://tsundoku.deepon.dev`
  - E2E: ログイン → 本の登録 → 本一覧表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)