### PR TITLE
feat: staging環境のTerraform化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,10 @@ npm-debug.log*
 
 # Test coverage
 coverage
+
+# Terraform
+*.tfstate
+*.tfstate.backup
+.terraform/
+.terraform.lock.hcl
+terraform.tfvars

--- a/.steering/20260211-terraform-setup/design.md
+++ b/.steering/20260211-terraform-setup/design.md
@@ -1,0 +1,245 @@
+# Terraform 環境構築 - 設計書
+
+## 意思決定
+
+### 1. IAM ユーザーの管理方法
+
+現在 `tsundoku-dragon-worker` が staging / production 共用で存在する。個人開発のため分離のメリットが薄く、共有のまま staging で管理する。
+
+| 案                                | メリット                           | デメリット                                    | 採用 |
+| --------------------------------- | ---------------------------------- | --------------------------------------------- | ---- |
+| A: 共有、staging で管理           | 移行不要、シンプル、管理コスト低い | production が staging の State に間接的に依存 | ✓    |
+| B: 環境別 IAM ユーザーに分離      | 完全な環境分離、最小権限           | 移行作業・シークレット再設定が必要            | -    |
+| C: shared/ ディレクトリで共有管理 | 明示的な共有リソース管理           | State が3つに増加、方針から逸脱               | -    |
+
+**選定理由**: 個人開発で事故リスクが低く、IAM ユーザー1つのために移行作業や管理コスト増は見合わない。staging で既存ユーザーを import し、production では IAM を管理対象外とする。
+
+**運用ルール**:
+
+- IAM ユーザー・ポリシーの変更は `terraform/staging/` で行う
+- IAM ポリシーは両環境のテーブルへのアクセスを許可する
+
+### 2. DNS レコードの管理
+
+Workers カスタムドメインは Cloudflare 側で自動的に DNS レコードを作成する場合がある。
+
+| 案                                     | メリット             | デメリット                       | 採用 |
+| -------------------------------------- | -------------------- | -------------------------------- | ---- |
+| A: DNS レコードを Terraform で管理     | 構成が明示的に見える | Workers が自動作成する場合に競合 | -    |
+| B: DNS レコードは管理対象外にする      | 競合リスクなし       | インフラの一部が管理外           | ✓    |
+| C: import して lifecycle ignore で管理 | コードに定義は残る   | ignore_changes の管理が煩雑      | -    |
+
+**選定理由**: Workers のカスタムドメイン設定時に Cloudflare が DNS レコードを自動管理する。Terraform で同じレコードを管理すると apply 時に競合する。DNS レコードは wrangler / Cloudflare ダッシュボードの責務とする。
+
+### 3. R2 バケットの扱い
+
+| 案                                | メリット                 | デメリット             | 採用 |
+| --------------------------------- | ------------------------ | ---------------------- | ---- |
+| A: 今回は作成しない               | YAGNI、不要な管理なし    | 後で追加作業が発生     | ✓    |
+| B: 空のバケットを先に作成しておく | 将来使うときにすぐ使える | 使わないリソースが存在 | -    |
+
+**選定理由**: まだ画像ストレージ機能は未実装。必要になった時点で追加する。
+
+---
+
+## ディレクトリ構成
+
+```
+terraform/
+├── staging/
+│   ├── main.tf          # プロバイダ設定、全リソース定義
+│   ├── variables.tf     # 変数定義
+│   ├── outputs.tf       # 出力値（wrangler.toml との対応）
+│   └── terraform.tfvars # 環境固有の値（.gitignore 対象）
+└── production/
+    ├── main.tf
+    ├── variables.tf
+    ├── outputs.tf
+    └── terraform.tfvars
+```
+
+---
+
+## リソース設計
+
+### staging 環境
+
+| Terraform リソース                | リソース名                  | 備考                               |
+| --------------------------------- | --------------------------- | ---------------------------------- |
+| `aws_dynamodb_table`              | `tsundoku-dragon-staging`   | 1 RCU / 1 WCU、既存を import       |
+| `aws_iam_user`                    | `tsundoku-dragon-worker`    | 既存共有ユーザーを import          |
+| `aws_iam_policy`                  | `tsundoku-dragon-dynamo-rw` | マネージドポリシー、既存を import  |
+| `aws_iam_user_policy_attachment`  | -                           | ユーザーとポリシーの紐づけ、import |
+| `cloudflare_workers_kv_namespace` | staging 用 KV               | 既存 ID で import                  |
+| `cloudflare_access_application`   | `tsundoku-dragon-staging`   | stg.tsundoku.deepon.dev            |
+| `cloudflare_access_policy`        | staging アクセスポリシー    | One-time PIN、指定メール           |
+
+### production 環境
+
+| Terraform リソース                | リソース名                   | 備考                         |
+| --------------------------------- | ---------------------------- | ---------------------------- |
+| `aws_dynamodb_table`              | `tsundoku-dragon-prod`       | 5 RCU / 5 WCU、既存を import |
+| `cloudflare_workers_kv_namespace` | production 用 KV             | 既存 ID で import            |
+| `cloudflare_access_application`   | `tsundoku-dragon-production` | tsundoku.deepon.dev          |
+| `cloudflare_access_policy`        | production アクセスポリシー  | One-time PIN、指定メール     |
+
+※ IAM ユーザーは staging で一元管理。production では管理対象外。
+
+---
+
+## 変数設計（variables.tf）
+
+### staging 用
+
+```hcl
+# AWS
+variable "aws_region" {}
+variable "dynamodb_table_name" {}
+variable "dynamodb_read_capacity" {}
+variable "dynamodb_write_capacity" {}
+
+# IAM（staging でのみ管理）
+variable "iam_user_name" {}
+variable "dynamodb_table_arns" {}       # IAM ポリシーで許可するテーブル ARN リスト
+
+# Cloudflare
+variable "cloudflare_account_id" {}
+variable "cloudflare_zone_id" {}       # deepon.dev のゾーン ID
+variable "kv_namespace_title" {}
+variable "access_app_name" {}
+variable "access_app_domain" {}
+variable "access_allowed_emails" {}    # Access で許可するメールアドレスリスト
+```
+
+### production 用
+
+```hcl
+# AWS
+variable "aws_region" {}
+variable "dynamodb_table_name" {}
+variable "dynamodb_read_capacity" {}
+variable "dynamodb_write_capacity" {}
+
+# Cloudflare
+variable "cloudflare_account_id" {}
+variable "cloudflare_zone_id" {}
+variable "kv_namespace_title" {}
+variable "access_app_name" {}
+variable "access_app_domain" {}
+variable "access_allowed_emails" {}
+```
+
+※ production には IAM 関連の変数なし
+
+## 出力設計（outputs.tf）
+
+### staging 用
+
+```hcl
+# wrangler.toml と対応する値
+output "dynamodb_table_name" {}        # → vars.DYNAMODB_TABLE_NAME
+output "kv_namespace_id" {}            # → kv_namespaces[].id
+output "iam_user_name" {}              # → IAM ユーザー名
+```
+
+### production 用
+
+```hcl
+output "dynamodb_table_name" {}        # → vars.DYNAMODB_TABLE_NAME
+output "kv_namespace_id" {}            # → kv_namespaces[].id
+```
+
+---
+
+## プロバイダ設定
+
+```hcl
+terraform {
+  required_version = ">= 1.14.1"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.31"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.16"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token  # 環境変数 CLOUDFLARE_API_TOKEN でも可
+}
+```
+
+---
+
+## 認証情報の管理
+
+| 認証情報                 | 設定方法                                                                           |
+| ------------------------ | ---------------------------------------------------------------------------------- |
+| AWS アクセスキー         | 環境変数 `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` または `~/.aws/credentials` |
+| Cloudflare API トークン  | 環境変数 `CLOUDFLARE_API_TOKEN` または `terraform.tfvars`                          |
+| Cloudflare アカウント ID | `terraform.tfvars`                                                                 |
+| Cloudflare ゾーン ID     | `terraform.tfvars`                                                                 |
+
+`terraform.tfvars` に機密情報を含めるため、`.gitignore` に追加する。
+
+---
+
+## import 対象リソース
+
+### staging（既存リソースの取り込み）
+
+| リソース             | import コマンド例                                                                                                                                       |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| DynamoDB テーブル    | `terraform import aws_dynamodb_table.main tsundoku-dragon-staging`                                                                                      |
+| IAM ユーザー         | `terraform import aws_iam_user.worker tsundoku-dragon-worker`                                                                                           |
+| IAM ポリシー         | `terraform import aws_iam_policy.dynamodb_access arn:aws:iam::<AWS_ACCOUNT_ID>:policy/tsundoku-dragon-dynamo-rw`                                        |
+| IAM ポリシーアタッチ | `terraform import aws_iam_user_policy_attachment.worker_dynamodb tsundoku-dragon-worker/arn:aws:iam::<AWS_ACCOUNT_ID>:policy/tsundoku-dragon-dynamo-rw` |
+| KV Namespace         | `terraform import cloudflare_workers_kv_namespace.main <account_id>/486c84b66f0842e798c973b5ea081976`                                                   |
+| Access Application   | `terraform import cloudflare_zero_trust_access_application.main accounts/<account_id>/<app_id>`                                                         |
+| Access Policy        | `terraform import cloudflare_zero_trust_access_policy.main <account_id>/<policy_id>`                                                                    |
+
+※ IAM はマネージドポリシー（`aws_iam_policy` + `aws_iam_user_policy_attachment`）。インラインポリシーではない。
+※ Cloudflare v5 プロバイダでは Access Application の import に `accounts/` プレフィックスが必要。Access Policy は app_id 不要。
+
+### production（既存リソースの取り込み）
+
+| リソース           | import コマンド例                                                                                     |
+| ------------------ | ----------------------------------------------------------------------------------------------------- |
+| DynamoDB テーブル  | `terraform import aws_dynamodb_table.main tsundoku-dragon-prod`                                       |
+| KV Namespace       | `terraform import cloudflare_workers_kv_namespace.main <account_id>/1f79768d91be42e586b4c7d3a186e94e` |
+| Access Application | `terraform import cloudflare_zero_trust_access_application.main accounts/<account_id>/<app_id>`       |
+| Access Policy      | `terraform import cloudflare_zero_trust_access_policy.main <account_id>/<policy_id>`                  |
+
+※ production では IAM は管理対象外。
+
+---
+
+## セキュリティ考慮事項
+
+- `terraform.tfvars` は `.gitignore` に追加し、Git にコミットしない
+- `*.tfstate` も `.gitignore` に追加（State にはシークレットが平文で含まれる）
+- IAM ポリシーは両環境のテーブルのみアクセス許可（`*` は使わない）
+
+---
+
+## 追加・変更するファイル
+
+| ファイル                                | 種別 | 責務                       |
+| --------------------------------------- | ---- | -------------------------- |
+| `terraform/staging/main.tf`             | 新規 | staging リソース定義       |
+| `terraform/staging/variables.tf`        | 新規 | staging 変数定義           |
+| `terraform/staging/outputs.tf`          | 新規 | staging 出力値             |
+| `terraform/staging/terraform.tfvars`    | 新規 | staging 環境固有値         |
+| `terraform/production/main.tf`          | 新規 | production リソース定義    |
+| `terraform/production/variables.tf`     | 新規 | production 変数定義        |
+| `terraform/production/outputs.tf`       | 新規 | production 出力値          |
+| `terraform/production/terraform.tfvars` | 新規 | production 環境固有値      |
+| `.gitignore`                            | 変更 | Terraform 関連ファイル追加 |

--- a/.steering/20260211-terraform-setup/requirements.md
+++ b/.steering/20260211-terraform-setup/requirements.md
@@ -1,0 +1,70 @@
+# Terraform 環境構築
+
+## 概要
+
+既存の手動構築済みインフラを Terraform で管理し、インフラの構成をコードとして宣言的に管理する。
+
+## 背景
+
+- 現在のインフラ（DynamoDB、IAM、KV Namespace、Cloudflare Access、DNS）はすべて手動構築済み
+- 構成変更の追跡が困難で、環境間の差異を把握しにくい
+- [planning/terraform-policy.md](../../planning/terraform-policy.md) で方針を策定済み
+
+## 要件
+
+### 機能要件
+
+#### staging 環境
+
+- [ ] AWS プロバイダ設定（ap-northeast-1）
+- [ ] DynamoDB テーブル（`tsundoku-dragon-staging`）の管理
+  - PK/SK: String型、プロビジョンドモード 1 RCU / 1 WCU
+- [ ] IAM ユーザー（`tsundoku-dragon-worker`）とポリシーの管理
+  - DynamoDB へのアクセス権限（staging テーブルのみ）
+- [ ] Cloudflare プロバイダ設定
+- [ ] KV Namespace（`486c84b66f0842e798c973b5ea081976`）の管理
+  - Firebase JWT 公開鍵キャッシュ用
+- [ ] Cloudflare Access アプリケーション（staging Web アクセス制限）
+  - `stg.tsundoku.deepon.dev` に対する One-time PIN 認証
+- [ ] DNS レコード（staging 環境用）
+  - `stg.tsundoku.deepon.dev`
+  - `api-stg.tsundoku.deepon.dev`
+- [ ] R2 バケット（将来の画像ストレージ用、staging 環境）
+- [ ] `terraform import` で既存リソースを取り込み
+- [ ] `terraform plan` で差分なし（No changes）を確認
+
+#### production 環境
+
+- [ ] staging と同様の構成で production 用リソースを管理
+- [ ] DynamoDB テーブル（`tsundoku-dragon-prod`）5 RCU / 5 WCU
+- [ ] KV Namespace（`1f79768d91be42e586b4c7d3a186e94e`）
+- [ ] DNS レコード（`tsundoku.deepon.dev`、`api.tsundoku.deepon.dev`）
+- [ ] Cloudflare Access アプリケーション（production、一時的）
+
+### 非機能要件
+
+- State はローカル管理（`.tfstate` を `.gitignore` に追加）
+- 機密情報（AWS シークレットキー、Cloudflare API トークン）は `terraform.tfvars` に記載し、`.gitignore` に追加
+- `terraform plan` の出力が明確で、意図しない変更がないこと
+
+## 受け入れ条件
+
+- [ ] `terraform/staging/` で `terraform plan` が No changes を示す
+- [ ] `terraform/production/` で `terraform plan` が No changes を示す
+- [ ] outputs に KV Namespace ID、DynamoDB テーブル名が含まれる（wrangler.toml との対応）
+- [ ] `.gitignore` に Terraform 関連ファイルが追加されている
+- [ ] 既存のアプリケーション動作に影響がない
+
+## 対象外（スコープ外）
+
+- Workers へのコードデプロイ（wrangler + GitHub Actions が担当）
+- Firebase Auth の管理
+- GitHub Actions ワークフローの変更
+- Cloudflare アカウント設定全般
+- リモートバックエンド（S3 + DynamoDB）への State 移行
+- モジュール化
+
+## 参考ドキュメント
+
+- [planning/terraform-policy.md](../../planning/terraform-policy.md)
+- [docs/CONTEXT.md](../../docs/CONTEXT.md)

--- a/.steering/20260211-terraform-setup/tasklist.md
+++ b/.steering/20260211-terraform-setup/tasklist.md
@@ -1,0 +1,155 @@
+# タスクリスト
+
+## タスク完了の原則
+
+**このファイルの全タスクが完了するまで作業を継続すること**
+
+### 必須ルール
+
+- 全てのタスクを `[x]` にすること
+- 未完了タスク `[ ]` を残したまま作業を終了しない
+- 「時間の都合」「難しい」などの理由でのスキップは禁止
+
+### スキップが許可されるケース
+
+技術的理由に該当する場合のみ:
+
+- 実装方針の変更により機能自体が不要になった
+- アーキテクチャ変更により別の実装方法に置き換わった
+
+スキップ時は理由を明記:
+
+```markdown
+- [~] タスク名 (スキップ理由: 具体的な技術的理由)
+```
+
+---
+
+## 進捗
+
+- 開始: 2026-02-11
+- 完了: （未完了）
+
+---
+
+## フェーズ1: 準備
+
+- [x] `.gitignore` に Terraform 関連エントリを追加
+- [x] `terraform/staging/` ディレクトリを作成
+- [x] `terraform/production/` ディレクトリを作成
+- [x] Terraform をインストール（`terraform version` で確認） → v1.14.1
+
+## フェーズ2: staging 環境の Terraform 化
+
+### 2-1: 事前情報収集
+
+- [x] IAM ポリシー情報を確認 → マネージドポリシー `tsundoku-dragon-dynamo-rw`（ARN は terraform.tfvars.example 参照）
+- [x] Cloudflare アカウント ID を確認（terraform.tfvars に記入済み）
+- [x] Cloudflare API トークンを作成（Terraform 用、必要な権限: Account.Workers KV Storage, Account.Access: Organizations/Identity Providers/Groups/Service Tokens/Apps and Policies）
+- [x] KV Namespace のタイトルを確認 → staging: `staging-PUBLIC_JWK_CACHE_KV` / production: `PUBLIC_JWK_CACHE_KV`
+- [x] Cloudflare Access アプリケーション ID を確認（staging） → terraform.tfvars に記入
+- [x] Cloudflare Access ポリシー ID を確認（staging） → terraform.tfvars に記入
+
+### 2-2: Terraform コード作成（staging）
+
+- [x] `terraform/staging/main.tf` を作成
+  - プロバイダ設定（AWS + Cloudflare）
+  - `aws_dynamodb_table.main`
+  - `aws_iam_user.worker`
+  - `aws_iam_policy.dynamodb_access` + `aws_iam_user_policy_attachment.worker_dynamodb`
+  - `cloudflare_workers_kv_namespace.main`
+  - `cloudflare_zero_trust_access_application.main`
+  - `cloudflare_zero_trust_access_policy.main`
+- [x] `terraform/staging/variables.tf` を作成
+- [x] `terraform/staging/outputs.tf` を作成
+- [x] `terraform/staging/terraform.tfvars.example` を作成（テンプレート）
+- [x] `terraform/staging/terraform.tfvars` を作成（実際の値を記入）
+
+### 2-3: 既存リソースの import（staging）
+
+- [x] `terraform init` を実行
+- [x] DynamoDB テーブルを import
+- [x] IAM ユーザーを import
+- [x] IAM ポリシーを import
+- [x] IAM ポリシーアタッチメントを import
+- [x] KV Namespace を import
+- [x] Access Application を import（v5 形式: `accounts/<account_id>/<app_id>`）
+- [x] Access Policy を import（v5 形式: `<account_id>/<policy_id>`）
+
+### 2-4: 差分確認と調整（staging）
+
+- [x] `terraform plan` を実行し、差分を確認
+- [x] 差分がある場合、Terraform コードを既存リソースに合わせて調整（v5 スキーマ変更、タグ追加、IAM ユーザーのアクセスキータグ手動削除）
+- [x] `terraform plan` で **No changes** になることを確認
+
+## フェーズ3: production 環境の Terraform 化
+
+### 3-1: 事前情報収集
+
+- [ ] Cloudflare Access アプリケーション ID を確認（production）
+- [ ] Cloudflare Access ポリシー ID を確認（production）
+
+### 3-2: Terraform コード作成（production）
+
+- [ ] `terraform/production/main.tf` を作成
+  - プロバイダ設定（AWS + Cloudflare）
+  - `aws_dynamodb_table.main`（tsundoku-dragon-prod）
+  - `cloudflare_workers_kv_namespace.main`
+  - `cloudflare_zero_trust_access_application.main`
+  - `cloudflare_zero_trust_access_policy.main`
+  - ※ IAM は管理対象外
+- [ ] `terraform/production/variables.tf` を作成
+- [ ] `terraform/production/outputs.tf` を作成
+- [ ] `terraform/production/terraform.tfvars.example` を作成（テンプレート）
+- [ ] `terraform/production/terraform.tfvars` を作成（実際の値を記入）
+
+### 3-3: 既存リソースの import（production）
+
+- [ ] `terraform init` を実行
+- [ ] DynamoDB テーブルを import
+  ```bash
+  terraform import aws_dynamodb_table.main tsundoku-dragon-prod
+  ```
+- [ ] KV Namespace を import
+  ```bash
+  terraform import cloudflare_workers_kv_namespace.main <account_id>/1f79768d91be42e586b4c7d3a186e94e
+  ```
+- [ ] Access Application を import
+- [ ] Access Policy を import
+
+### 3-4: 差分確認と調整（production）
+
+- [ ] `terraform plan` を実行し、差分を確認
+- [ ] 差分がある場合、Terraform コードを既存リソースに合わせて調整
+- [ ] `terraform plan` で **No changes** になることを確認
+
+## フェーズ4: 検証・仕上げ
+
+- [ ] staging で `terraform plan` を再実行し、No changes を確認
+- [ ] production で `terraform plan` を再実行し、No changes を確認
+- [ ] `terraform output` で出力値が wrangler.toml の値と一致することを確認
+- [ ] 既存のアプリケーション動作に影響がないことを確認（staging にアクセス）
+- [ ] Terraform 関連ファイルが `.gitignore` で正しく除外されていることを確認
+- [ ] コミット・プッシュ（`.tf` ファイルと `.tfvars.example` のみ。`.tfstate` / `terraform.tfvars` は除外）
+
+---
+
+## 今回のスコープ外（次回以降の対応）
+
+- [ ] R2 バケットの Terraform 管理（画像ストレージ機能の実装時に追加）
+
+---
+
+## 振り返り
+
+### うまくいったこと
+
+-
+
+### 改善点
+
+-
+
+### 次回への学び
+
+-

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 nodejs 22.21.1
+terraform 1.14.1

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -1,0 +1,142 @@
+terraform {
+  required_version = ">= 1.14.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.31"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.16"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
+}
+
+# =============================================================================
+# AWS - DynamoDB
+# =============================================================================
+
+resource "aws_dynamodb_table" "main" {
+  name                        = var.dynamodb_table_name
+  billing_mode                = "PROVISIONED"
+  read_capacity               = var.dynamodb_read_capacity
+  write_capacity              = var.dynamodb_write_capacity
+  deletion_protection_enabled = true
+
+  hash_key  = "PK"
+  range_key = "SK"
+
+  attribute {
+    name = "PK"
+    type = "S"
+  }
+
+  attribute {
+    name = "SK"
+    type = "S"
+  }
+
+  tags = {
+    Project     = "tsundoku-dragon"
+    Environment = "staging"
+  }
+}
+
+# =============================================================================
+# AWS - IAM（staging で一元管理）
+# =============================================================================
+
+resource "aws_iam_user" "worker" {
+  name = var.iam_user_name
+
+  tags = {
+    Project = "tsundoku-dragon"
+  }
+}
+
+resource "aws_iam_policy" "dynamodb_access" {
+  name = "tsundoku-dragon-dynamo-rw"
+
+  tags = {
+    Project = "tsundoku-dragon"
+  }
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetItem",
+          "dynamodb:PutItem",
+          "dynamodb:UpdateItem",
+          "dynamodb:DeleteItem",
+          "dynamodb:Query",
+          "dynamodb:Scan",
+        ]
+        Resource = var.dynamodb_table_arns
+      }
+    ]
+  })
+}
+
+resource "aws_iam_user_policy_attachment" "worker_dynamodb" {
+  user       = aws_iam_user.worker.name
+  policy_arn = aws_iam_policy.dynamodb_access.arn
+}
+
+# =============================================================================
+# Cloudflare - KV Namespace
+# =============================================================================
+
+resource "cloudflare_workers_kv_namespace" "main" {
+  account_id = var.cloudflare_account_id
+  title      = var.kv_namespace_title
+}
+
+# =============================================================================
+# Cloudflare - Access（v5 で zero_trust_ プレフィックスに変更）
+# =============================================================================
+
+resource "cloudflare_zero_trust_access_application" "main" {
+  account_id                 = var.cloudflare_account_id
+  name                       = var.access_app_name
+  domain                     = var.access_app_domain
+  type                       = "self_hosted"
+  session_duration           = "24h"
+  auto_redirect_to_identity  = false
+  enable_binding_cookie      = false
+  http_only_cookie_attribute = false
+  options_preflight_bypass   = false
+
+  policies = [
+    {
+      id         = cloudflare_zero_trust_access_policy.main.id
+      precedence = 1
+    }
+  ]
+}
+
+resource "cloudflare_zero_trust_access_policy" "main" {
+  account_id       = var.cloudflare_account_id
+  name             = "Allow owner"
+  decision         = "allow"
+  session_duration = "24h"
+
+  include = [
+    for email in var.access_allowed_emails : {
+      email = {
+        email = email
+      }
+    }
+  ]
+}

--- a/terraform/staging/outputs.tf
+++ b/terraform/staging/outputs.tf
@@ -1,0 +1,16 @@
+# wrangler.toml と対応する出力値
+
+output "dynamodb_table_name" {
+  description = "DynamoDB テーブル名 → wrangler.toml vars.DYNAMODB_TABLE_NAME"
+  value       = aws_dynamodb_table.main.name
+}
+
+output "kv_namespace_id" {
+  description = "KV Namespace ID → wrangler.toml kv_namespaces[].id"
+  value       = cloudflare_workers_kv_namespace.main.id
+}
+
+output "iam_user_name" {
+  description = "IAM ユーザー名"
+  value       = aws_iam_user.worker.name
+}

--- a/terraform/staging/terraform.tfvars.example
+++ b/terraform/staging/terraform.tfvars.example
@@ -1,0 +1,22 @@
+# AWS
+aws_region             = "ap-northeast-1"
+dynamodb_table_name    = "tsundoku-dragon-staging"
+dynamodb_read_capacity  = 1
+dynamodb_write_capacity = 1
+
+# IAM（staging で一元管理：両環境のテーブル ARN を指定）
+iam_user_name = "tsundoku-dragon-worker"
+dynamodb_table_arns = [
+  "arn:aws:dynamodb:ap-northeast-1:<ACCOUNT_ID>:table/tsundoku-dragon-staging",
+  "arn:aws:dynamodb:ap-northeast-1:<ACCOUNT_ID>:table/tsundoku-dragon-prod",
+]
+
+# Cloudflare
+cloudflare_api_token   = "<CLOUDFLARE_API_TOKEN>"
+cloudflare_account_id  = "<CLOUDFLARE_ACCOUNT_ID>"
+kv_namespace_title     = "<KV_NAMESPACE_TITLE>"  # Cloudflare ダッシュボードで確認
+
+# Cloudflare Access
+access_app_name        = "tsundoku-dragon-staging"
+access_app_domain      = "stg.tsundoku.deepon.dev"
+access_allowed_emails  = ["your-email@example.com"]

--- a/terraform/staging/variables.tf
+++ b/terraform/staging/variables.tf
@@ -1,0 +1,73 @@
+# =============================================================================
+# AWS
+# =============================================================================
+
+variable "aws_region" {
+  description = "AWS リージョン"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "dynamodb_table_name" {
+  description = "DynamoDB テーブル名"
+  type        = string
+}
+
+variable "dynamodb_read_capacity" {
+  description = "DynamoDB 読み取りキャパシティユニット"
+  type        = number
+}
+
+variable "dynamodb_write_capacity" {
+  description = "DynamoDB 書き込みキャパシティユニット"
+  type        = number
+}
+
+# =============================================================================
+# AWS - IAM（staging で一元管理）
+# =============================================================================
+
+variable "iam_user_name" {
+  description = "IAM ユーザー名（Cloudflare Workers から DynamoDB にアクセスする用）"
+  type        = string
+}
+
+variable "dynamodb_table_arns" {
+  description = "IAM ポリシーで許可する DynamoDB テーブルの ARN リスト"
+  type        = list(string)
+}
+
+# =============================================================================
+# Cloudflare
+# =============================================================================
+
+variable "cloudflare_api_token" {
+  description = "Cloudflare API トークン"
+  type        = string
+  sensitive   = true
+}
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare アカウント ID"
+  type        = string
+}
+
+variable "kv_namespace_title" {
+  description = "KV Namespace のタイトル"
+  type        = string
+}
+
+variable "access_app_name" {
+  description = "Cloudflare Access アプリケーション名"
+  type        = string
+}
+
+variable "access_app_domain" {
+  description = "Cloudflare Access で保護するドメイン"
+  type        = string
+}
+
+variable "access_allowed_emails" {
+  description = "Cloudflare Access で許可するメールアドレスリスト"
+  type        = list(string)
+}


### PR DESCRIPTION
## Summary

- staging環境の既存リソースをTerraformで管理するための設定を追加
- AWS (DynamoDB, IAM) と Cloudflare (KV Namespace, Access) の計7リソースを`terraform import`で取り込み済み
- `terraform plan`でNo changesを確認済み

## 管理対象リソース

| リソース | 種別 |
|---|---|
| `aws_dynamodb_table.main` | DynamoDB テーブル (tsundoku-dragon-staging) |
| `aws_iam_user.worker` | IAM ユーザー (共有、staging で一元管理) |
| `aws_iam_policy.dynamodb_access` | IAM マネージドポリシー |
| `aws_iam_user_policy_attachment.worker_dynamodb` | ポリシーアタッチメント |
| `cloudflare_workers_kv_namespace.main` | KV Namespace |
| `cloudflare_zero_trust_access_application.main` | Access Application |
| `cloudflare_zero_trust_access_policy.main` | Access Policy |

## 設計判断

- IAM ユーザーは staging/production 共有のまま staging で一元管理（個人開発のため分離のメリットが薄い）
- DNS レコードは管理対象外（Workers カスタムドメインが自動管理するため競合回避）
- R2 バケットは今回スコープ外（YAGNI）

## セキュリティ

- `terraform.tfvars` / `*.tfstate` は `.gitignore` で除外済み
- `terraform.tfvars.example` はプレースホルダーのみ

## Test plan

- [x] `terraform plan` で No changes を確認
- [x] `terraform apply` で Resources: 0 added, 0 changed, 0 destroyed を確認
- [x] 機密情報がコミットに含まれていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)