### PR TITLE
refactor: ErrorCode enumを導入しエラーレスポンスにcodeフィールドを追加

### DIFF
--- a/.steering/20260313-refactor-error-handling/design.md
+++ b/.steering/20260313-refactor-error-handling/design.md
@@ -1,0 +1,117 @@
+# 設計書
+
+## 意思決定
+
+### 採用した設計
+
+既存の `AppError` クラスに `ErrorCode` enum を追加し、`BadRequestError` / `NotFoundError` のコンストラクタ経由でエラーコードを受け取る。グローバルエラーハンドラはレスポンスに `code` フィールドを追加する。
+
+### 代替案との比較
+
+| 案                                              | メリット                         | デメリット               | 採用 |
+| ----------------------------------------------- | -------------------------------- | ------------------------ | ---- |
+| 案A: 既存 AppError に code を追加               | 変更が最小限、既存構造を活かせる | -                        | ✓    |
+| 案B: エラーコードごとに個別のエラークラスを作成 | 型が厳密                         | クラス数が多くなりすぎる | -    |
+| 案C: エラーコードをルート層で付与               | -                                | 責務分離に反する         | -    |
+
+### 選定理由
+
+既に `AppError` → `BadRequestError` / `NotFoundError` の継承構造が確立されており、`code` プロパティを追加するだけで目的を達成できる。サービス層でエラーコードを指定する方が責務として自然。
+
+## データフロー
+
+### エラー発生時のフロー
+
+1. サービス層で `throw new NotFoundError(ErrorCode.BOOK_NOT_FOUND, 'Book not found')` を投げる
+2. Honoのルートハンドラがキャッチせず、そのまま `app.onError` へ伝播
+3. `handleError` で `AppError` を判定し、`{ error: message, code: errorCode }` を返す
+
+## コンポーネント設計
+
+### 追加・変更するファイル
+
+| ファイル                                      | 種別 | 責務                                       |
+| --------------------------------------------- | ---- | ------------------------------------------ |
+| `apps/api/src/lib/errors.ts`                  | 変更 | ErrorCode enum 追加、AppError に code 追加 |
+| `apps/api/src/services/bookService.ts`        | 変更 | エラー throw に ErrorCode を指定           |
+| `apps/api/src/services/battleService.ts`      | 変更 | エラー throw に ErrorCode を指定           |
+| `apps/api/src/lib/errors.test.ts`             | 変更 | ErrorCode 関連テスト追加                   |
+| `apps/api/src/services/bookService.test.ts`   | 変更 | エラーコード検証追加                       |
+| `apps/api/src/services/battleService.test.ts` | 変更 | エラーコード検証追加                       |
+| `apps/api/src/routes/books.test.ts`           | 変更 | レスポンスの code フィールド検証           |
+
+### 主要コンポーネント
+
+#### ErrorCode enum
+
+**責務**: アプリケーション全体のエラーコードを一元管理
+
+```typescript
+export enum ErrorCode {
+  BOOK_NOT_FOUND = 'BOOK_NOT_FOUND',
+  CANNOT_UPDATE_ARCHIVED_BOOK = 'CANNOT_UPDATE_ARCHIVED_BOOK',
+  BOOK_IS_ALREADY_ARCHIVED = 'BOOK_IS_ALREADY_ARCHIVED',
+  BOOK_NOT_IN_READING_STATUS = 'BOOK_NOT_IN_READING_STATUS',
+  CAN_ONLY_RESET_COMPLETED_BOOKS = 'CAN_ONLY_RESET_COMPLETED_BOOKS',
+}
+```
+
+#### AppError（変更）
+
+```typescript
+export class AppError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    message: string,
+    public readonly code?: ErrorCode
+  ) {
+    super(message);
+    this.name = 'AppError';
+  }
+}
+```
+
+#### BadRequestError / NotFoundError（変更）
+
+```typescript
+export class BadRequestError extends AppError {
+  constructor(code: ErrorCode, message: string) {
+    super(400, message, code);
+    this.name = 'BadRequestError';
+  }
+}
+
+export class NotFoundError extends AppError {
+  constructor(code: ErrorCode, message: string) {
+    super(404, message, code);
+    this.name = 'NotFoundError';
+  }
+}
+```
+
+#### handleError（変更）
+
+```typescript
+export function handleError(err: Error, c: Context): Response {
+  if (err instanceof AppError) {
+    return c.json(
+      { error: err.message, ...(err.code && { code: err.code }) },
+      err.statusCode as ContentfulStatusCode
+    );
+  }
+  console.error('Unexpected error:', err);
+  return c.json({ error: 'Internal Server Error' }, 500);
+}
+```
+
+## テスト戦略
+
+### ユニットテスト
+
+- `errors.test.ts`: ErrorCode enum の存在確認、AppError/BadRequestError/NotFoundError の code プロパティ検証
+- `bookService.test.ts`: 各エラーケースで正しい ErrorCode が投げられることを検証
+- `battleService.test.ts`: 各エラーケースで正しい ErrorCode が投げられることを検証
+
+### ルートテスト
+
+- `books.test.ts`: エラーレスポンスに `code` フィールドが含まれることを検証

--- a/.steering/20260313-refactor-error-handling/requirements.md
+++ b/.steering/20260313-refactor-error-handling/requirements.md
@@ -1,0 +1,44 @@
+# カスタムエラークラスとグローバルエラーハンドラーの改善
+
+## 概要
+
+既存の `AppError` にエラーコード（`ErrorCode` enum）を導入し、エラーレスポンスに構造化された `code` フィールドを追加する。
+
+## 背景
+
+- 現在の `AppError` は `statusCode` と `message` のみ保持しており、クライアントがエラーを識別するには文字列比較（`error.message === '...'`）に依存している
+- エラーコードを導入することで、クライアント側でのエラーハンドリングが型安全かつ堅牢になる
+- Issue: https://github.com/dznbk/tsundoku-dragon/issues/80
+
+## 要件
+
+### 機能要件
+
+- [x] `ErrorCode` enum を定義する（BOOK_NOT_FOUND, CANNOT_UPDATE_ARCHIVED_BOOK, BOOK_IS_ALREADY_ARCHIVED, BOOK_NOT_IN_READING_STATUS, CAN_ONLY_RESET_COMPLETED_BOOKS）
+- [x] `AppError` クラスに `code` プロパティ（ErrorCode 型）を追加する
+- [x] `BadRequestError` / `NotFoundError` のコンストラクタに `code` パラメータを追加する
+- [x] グローバルエラーハンドラ `handleError` のレスポンスに `code` フィールドを含める
+- [x] 各サービス層のエラー throw 箇所で適切な `ErrorCode` を指定する
+- [x] 既存テストをエラーコード対応に更新する
+
+### 非機能要件
+
+- 既存のルートハンドラには影響を与えない（既にクリーンな実装）
+- 後方互換性: エラーレスポンスに `error`（メッセージ）フィールドは残す
+
+## 受け入れ条件
+
+- [x] エラーレスポンスに `{ error: "メッセージ", code: "ERROR_CODE" }` 形式で返る
+- [x] 全ユニットテスト・ルートテストがパスする
+- [x] lint / typecheck / format がパスする
+
+## 対象外（スコープ外）
+
+- フロントエンドのエラーハンドリング変更
+- 新しいエラーミドルウェア（既存の `handleError` を拡張する）
+- ルートハンドラの変更（既にクリーン）
+
+## 参考ドキュメント
+
+- [docs/development-guidelines.md](../../docs/development-guidelines.md)
+- [docs/repository-structure.md](../../docs/repository-structure.md)

--- a/.steering/20260313-refactor-error-handling/tasklist.md
+++ b/.steering/20260313-refactor-error-handling/tasklist.md
@@ -1,0 +1,78 @@
+# タスクリスト
+
+## タスク完了の原則
+
+**このファイルの全タスクが完了するまで作業を継続すること**
+
+### 必須ルール
+
+- 全てのタスクを `[x]` にすること
+- 未完了タスク `[ ]` を残したまま作業を終了しない
+- 「時間の都合」「難しい」などの理由でのスキップは禁止
+
+### スキップが許可されるケース
+
+技術的理由に該当する場合のみ:
+
+- 実装方針の変更により機能自体が不要になった
+- アーキテクチャ変更により別の実装方法に置き換わった
+
+スキップ時は理由を明記:
+
+```markdown
+- [~] タスク名 (スキップ理由: 具体的な技術的理由)
+```
+
+---
+
+## 進捗
+
+- 開始: 2026-03-13
+- 完了: 2026-03-13
+
+---
+
+## フェーズ1: ErrorCode enum と AppError の拡張
+
+- [x] `apps/api/src/lib/errors.ts` に `ErrorCode` enum を追加する
+- [x] `AppError` コンストラクタに `code?: ErrorCode` パラメータを追加する
+- [x] `BadRequestError` コンストラクタを `(code: ErrorCode, message: string)` に変更する
+- [x] `NotFoundError` コンストラクタを `(code: ErrorCode, message: string)` に変更する
+- [x] `handleError` のレスポンスに `code` フィールドを追加する
+- [x] `apps/api/src/lib/errors.test.ts` を ErrorCode 対応に更新する
+
+## フェーズ2: サービス層の更新
+
+- [x] `apps/api/src/services/bookService.ts` の全エラー throw に ErrorCode を追加する
+- [x] `apps/api/src/services/battleService.ts` の全エラー throw に ErrorCode を追加する
+- [x] `apps/api/src/services/bookService.test.ts` にエラーコード検証を追加する
+- [x] `apps/api/src/services/battleService.test.ts` にエラーコード検証を追加する
+
+## フェーズ3: ルートテストの更新
+
+- [x] `apps/api/src/routes/books.test.ts` のエラーレスポンス検証に `code` フィールドを追加する
+
+## フェーズ4: 品質チェック
+
+- [x] テストが通ることを確認 (`npm run test:all`)
+- [x] リントエラーがないことを確認 (`npm run lint`)
+- [x] 型エラーがないことを確認 (`npm run typecheck`)
+- [x] フォーマットエラーがないことを確認 (`npm run format:check`)
+
+---
+
+## 振り返り
+
+### うまくいったこと
+
+- 既存の `AppError` 継承構造がしっかりしていたため、`ErrorCode` enum と `code` プロパティの追加だけで目的を達成できた
+- ルートハンドラは既にクリーン（try-catch不要）だったため、変更不要だった
+- テストの修正も `toMatchObject` を活用し、既存アサーションとの共存がスムーズだった
+
+### 改善点
+
+- `index.test.ts` の `BadRequestError` コンストラクタ変更への対応を計画段階で見落としていた
+
+### 次回への学び
+
+- コンストラクタシグネチャの破壊的変更がある場合、全使用箇所（テスト含む）を事前にGrepで洗い出すべき

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { describe, it, expect } from 'vitest';
 import app from './index';
-import { BadRequestError, handleError } from './lib/errors';
+import { BadRequestError, ErrorCode, handleError } from './lib/errors';
 
 const mockEnv = {
   ALLOWED_ORIGINS: 'http://localhost:5173',
@@ -19,7 +19,10 @@ describe('API', () => {
 describe('グローバルエラーハンドラ', () => {
   const testApp = new Hono();
   testApp.get('/test-bad-request', () => {
-    throw new BadRequestError('test bad request');
+    throw new BadRequestError(
+      ErrorCode.CANNOT_UPDATE_ARCHIVED_BOOK,
+      'test bad request'
+    );
   });
   testApp.get('/test-unknown', () => {
     throw new Error('unexpected error');
@@ -30,8 +33,9 @@ describe('グローバルエラーハンドラ', () => {
     const res = await testApp.request('/test-bad-request');
 
     expect(res.status).toBe(400);
-    const body = (await res.json()) as { error: string };
+    const body = (await res.json()) as { error: string; code: string };
     expect(body.error).toBe('test bad request');
+    expect(body.code).toBe(ErrorCode.CANNOT_UPDATE_ARCHIVED_BOOK);
   });
 
   it('AppError以外のエラーは500を返す', async () => {

--- a/apps/api/src/lib/errors.test.ts
+++ b/apps/api/src/lib/errors.test.ts
@@ -1,5 +1,21 @@
 import { describe, it, expect } from 'vitest';
-import { AppError, BadRequestError, NotFoundError } from './errors';
+import { AppError, BadRequestError, NotFoundError, ErrorCode } from './errors';
+
+describe('ErrorCode', () => {
+  it('全てのエラーコードが定義されている', () => {
+    expect(ErrorCode.BOOK_NOT_FOUND).toBe('BOOK_NOT_FOUND');
+    expect(ErrorCode.CANNOT_UPDATE_ARCHIVED_BOOK).toBe(
+      'CANNOT_UPDATE_ARCHIVED_BOOK'
+    );
+    expect(ErrorCode.BOOK_IS_ALREADY_ARCHIVED).toBe('BOOK_IS_ALREADY_ARCHIVED');
+    expect(ErrorCode.BOOK_NOT_IN_READING_STATUS).toBe(
+      'BOOK_NOT_IN_READING_STATUS'
+    );
+    expect(ErrorCode.CAN_ONLY_RESET_COMPLETED_BOOKS).toBe(
+      'CAN_ONLY_RESET_COMPLETED_BOOKS'
+    );
+  });
+});
 
 describe('AppError', () => {
   it('statusCodeとmessageを保持する', () => {
@@ -8,6 +24,18 @@ describe('AppError', () => {
     expect(error.statusCode).toBe(400);
     expect(error.message).toBe('test error');
     expect(error.name).toBe('AppError');
+  });
+
+  it('codeを保持する', () => {
+    const error = new AppError(404, 'not found', ErrorCode.BOOK_NOT_FOUND);
+
+    expect(error.code).toBe(ErrorCode.BOOK_NOT_FOUND);
+  });
+
+  it('codeが未指定の場合はundefined', () => {
+    const error = new AppError(500, 'test');
+
+    expect(error.code).toBeUndefined();
   });
 
   it('Errorのインスタンスである', () => {
@@ -19,16 +47,23 @@ describe('AppError', () => {
 });
 
 describe('BadRequestError', () => {
-  it('statusCodeが400である', () => {
-    const error = new BadRequestError('invalid input');
+  it('statusCodeが400でcodeを保持する', () => {
+    const error = new BadRequestError(
+      ErrorCode.CANNOT_UPDATE_ARCHIVED_BOOK,
+      'Cannot update archived book'
+    );
 
     expect(error.statusCode).toBe(400);
-    expect(error.message).toBe('invalid input');
+    expect(error.code).toBe(ErrorCode.CANNOT_UPDATE_ARCHIVED_BOOK);
+    expect(error.message).toBe('Cannot update archived book');
     expect(error.name).toBe('BadRequestError');
   });
 
   it('AppErrorのインスタンスである', () => {
-    const error = new BadRequestError('test');
+    const error = new BadRequestError(
+      ErrorCode.BOOK_IS_ALREADY_ARCHIVED,
+      'test'
+    );
 
     expect(error).toBeInstanceOf(Error);
     expect(error).toBeInstanceOf(AppError);
@@ -37,16 +72,17 @@ describe('BadRequestError', () => {
 });
 
 describe('NotFoundError', () => {
-  it('statusCodeが404である', () => {
-    const error = new NotFoundError('not found');
+  it('statusCodeが404でcodeを保持する', () => {
+    const error = new NotFoundError(ErrorCode.BOOK_NOT_FOUND, 'Book not found');
 
     expect(error.statusCode).toBe(404);
-    expect(error.message).toBe('not found');
+    expect(error.code).toBe(ErrorCode.BOOK_NOT_FOUND);
+    expect(error.message).toBe('Book not found');
     expect(error.name).toBe('NotFoundError');
   });
 
   it('AppErrorのインスタンスである', () => {
-    const error = new NotFoundError('test');
+    const error = new NotFoundError(ErrorCode.BOOK_NOT_FOUND, 'test');
 
     expect(error).toBeInstanceOf(Error);
     expect(error).toBeInstanceOf(AppError);

--- a/apps/api/src/lib/errors.ts
+++ b/apps/api/src/lib/errors.ts
@@ -2,13 +2,25 @@ import type { Context } from 'hono';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
 
 /**
+ * アプリケーション全体のエラーコードを一元管理する enum
+ */
+export enum ErrorCode {
+  BOOK_NOT_FOUND = 'BOOK_NOT_FOUND',
+  CANNOT_UPDATE_ARCHIVED_BOOK = 'CANNOT_UPDATE_ARCHIVED_BOOK',
+  BOOK_IS_ALREADY_ARCHIVED = 'BOOK_IS_ALREADY_ARCHIVED',
+  BOOK_NOT_IN_READING_STATUS = 'BOOK_NOT_IN_READING_STATUS',
+  CAN_ONLY_RESET_COMPLETED_BOOKS = 'CAN_ONLY_RESET_COMPLETED_BOOKS',
+}
+
+/**
  * アプリケーションエラーの基底クラス
- * HTTPステータスコードを保持し、グローバルエラーハンドラで変換される
+ * HTTPステータスコードとエラーコードを保持し、グローバルエラーハンドラで変換される
  */
 export class AppError extends Error {
   constructor(
     public readonly statusCode: number,
-    message: string
+    message: string,
+    public readonly code?: ErrorCode
   ) {
     super(message);
     this.name = 'AppError';
@@ -19,8 +31,8 @@ export class AppError extends Error {
  * ビジネスルール違反を表す400エラー
  */
 export class BadRequestError extends AppError {
-  constructor(message: string) {
-    super(400, message);
+  constructor(code: ErrorCode, message: string) {
+    super(400, message, code);
     this.name = 'BadRequestError';
   }
 }
@@ -29,8 +41,8 @@ export class BadRequestError extends AppError {
  * リソースが見つからないことを表す404エラー
  */
 export class NotFoundError extends AppError {
-  constructor(message: string) {
-    super(404, message);
+  constructor(code: ErrorCode, message: string) {
+    super(404, message, code);
     this.name = 'NotFoundError';
   }
 }
@@ -42,7 +54,7 @@ export class NotFoundError extends AppError {
 export function handleError(err: Error, c: Context): Response {
   if (err instanceof AppError) {
     return c.json(
-      { error: err.message },
+      { error: err.message, ...(err.code && { code: err.code }) },
       err.statusCode as ContentfulStatusCode
     );
   }

--- a/apps/api/src/routes/books.test.ts
+++ b/apps/api/src/routes/books.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Hono } from 'hono';
 import books from './books';
-import { handleError } from '../lib/errors';
+import { handleError, ErrorCode } from '../lib/errors';
 import type { Book } from '@tsundoku-dragon/shared';
 
 vi.mock('nanoid', () => ({
@@ -224,8 +224,9 @@ describe('Books Routes', () => {
       const res = await app.request('/books/not-exist', {}, mockEnv);
 
       expect(res.status).toBe(404);
-      const body = (await res.json()) as { error: string };
+      const body = (await res.json()) as { error: string; code: string };
       expect(body.error).toBe('Book not found');
+      expect(body.code).toBe(ErrorCode.BOOK_NOT_FOUND);
     });
   });
 
@@ -293,8 +294,9 @@ describe('Books Routes', () => {
       );
 
       expect(res.status).toBe(400);
-      const body = (await res.json()) as { error: string };
+      const body = (await res.json()) as { error: string; code: string };
       expect(body.error).toBe('Cannot update archived book');
+      expect(body.code).toBe(ErrorCode.CANNOT_UPDATE_ARCHIVED_BOOK);
     });
   });
 
@@ -347,8 +349,9 @@ describe('Books Routes', () => {
       );
 
       expect(res.status).toBe(400);
-      const body = (await res.json()) as { error: string };
+      const body = (await res.json()) as { error: string; code: string };
       expect(body.error).toBe('Book is already archived');
+      expect(body.code).toBe(ErrorCode.BOOK_IS_ALREADY_ARCHIVED);
     });
   });
 
@@ -413,8 +416,9 @@ describe('Books Routes', () => {
       );
 
       expect(res.status).toBe(400);
-      const body = (await res.json()) as { error: string };
+      const body = (await res.json()) as { error: string; code: string };
       expect(body.error).toBe('Can only reset completed books');
+      expect(body.code).toBe(ErrorCode.CAN_ONLY_RESET_COMPLETED_BOOKS);
     });
   });
 
@@ -462,6 +466,8 @@ describe('Books Routes', () => {
       const res = await app.request('/books/not-exist/logs', {}, mockEnv);
 
       expect(res.status).toBe(404);
+      const body = (await res.json()) as { error: string; code: string };
+      expect(body.code).toBe(ErrorCode.BOOK_NOT_FOUND);
     });
 
     it('limitとcursorをクエリパラメータで受け取る', async () => {
@@ -566,8 +572,9 @@ describe('Books Routes', () => {
       );
 
       expect(res.status).toBe(404);
-      const body = (await res.json()) as { error: string };
+      const body = (await res.json()) as { error: string; code: string };
       expect(body.error).toBe('Book not found');
+      expect(body.code).toBe(ErrorCode.BOOK_NOT_FOUND);
     });
 
     it('reading以外のstatusは400を返す', async () => {
@@ -587,8 +594,9 @@ describe('Books Routes', () => {
       );
 
       expect(res.status).toBe(400);
-      const body = (await res.json()) as { error: string };
+      const body = (await res.json()) as { error: string; code: string };
       expect(body.error).toBe('Book is not in reading status');
+      expect(body.code).toBe(ErrorCode.BOOK_NOT_IN_READING_STATUS);
     });
 
     it('pagesReadが0以下は400を返す', async () => {

--- a/apps/api/src/services/battleService.test.ts
+++ b/apps/api/src/services/battleService.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { BattleService } from './battleService';
-import { BadRequestError, NotFoundError } from '../lib/errors';
+import { ErrorCode } from '../lib/errors';
 import type { Book } from '@tsundoku-dragon/shared';
 
 vi.mock('nanoid', () => ({
@@ -110,7 +110,7 @@ describe('BattleService', () => {
 
       await expect(
         service.getBookLogs('user-123', 'not-exist')
-      ).rejects.toThrow(NotFoundError);
+      ).rejects.toMatchObject({ code: ErrorCode.BOOK_NOT_FOUND });
       expect(mockFindLogs).not.toHaveBeenCalled();
     });
 
@@ -219,7 +219,7 @@ describe('BattleService', () => {
 
       await expect(
         service.recordBattle('user-123', 'not-exist', { pagesRead: 30 })
-      ).rejects.toThrow(NotFoundError);
+      ).rejects.toMatchObject({ code: ErrorCode.BOOK_NOT_FOUND });
       expect(mockSaveLog).not.toHaveBeenCalled();
       expect(mockUpdate).not.toHaveBeenCalled();
     });
@@ -232,7 +232,7 @@ describe('BattleService', () => {
 
       await expect(
         service.recordBattle('user-123', 'book-123', { pagesRead: 30 })
-      ).rejects.toThrow(BadRequestError);
+      ).rejects.toMatchObject({ code: ErrorCode.BOOK_NOT_IN_READING_STATUS });
     });
 
     it('archived状態の本はエラー', async () => {
@@ -243,7 +243,7 @@ describe('BattleService', () => {
 
       await expect(
         service.recordBattle('user-123', 'book-123', { pagesRead: 30 })
-      ).rejects.toThrow(BadRequestError);
+      ).rejects.toMatchObject({ code: ErrorCode.BOOK_NOT_IN_READING_STATUS });
     });
 
     describe('経験値システム', () => {

--- a/apps/api/src/services/battleService.ts
+++ b/apps/api/src/services/battleService.ts
@@ -7,7 +7,7 @@ import {
 import { SkillRepository } from '../repositories/skillRepository';
 import type { CreateBattleLogInput } from '../types/api';
 import type { Env } from '../lib/dynamodb';
-import { BadRequestError, NotFoundError } from '../lib/errors';
+import { BadRequestError, NotFoundError, ErrorCode } from '../lib/errors';
 import { defeatBonus as calcDefeatBonus } from '../lib/expCalculator';
 
 export interface SkillResult {
@@ -44,7 +44,7 @@ export class BattleService {
   ): Promise<LogsQueryResult> {
     const book = await this.bookRepository.findById(userId, bookId);
     if (!book) {
-      throw new NotFoundError('Book not found');
+      throw new NotFoundError(ErrorCode.BOOK_NOT_FOUND, 'Book not found');
     }
 
     return this.bookRepository.findLogs(userId, bookId, options);
@@ -57,11 +57,14 @@ export class BattleService {
   ): Promise<RecordBattleResult> {
     const book = await this.bookRepository.findById(userId, bookId);
     if (!book) {
-      throw new NotFoundError('Book not found');
+      throw new NotFoundError(ErrorCode.BOOK_NOT_FOUND, 'Book not found');
     }
 
     if (book.status !== 'reading') {
-      throw new BadRequestError('Book is not in reading status');
+      throw new BadRequestError(
+        ErrorCode.BOOK_NOT_IN_READING_STATUS,
+        'Book is not in reading status'
+      );
     }
 
     const now = new Date().toISOString();

--- a/apps/api/src/services/bookService.test.ts
+++ b/apps/api/src/services/bookService.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { BookService } from './bookService';
-import { NotFoundError, ErrorCode } from '../lib/errors';
+import { ErrorCode } from '../lib/errors';
 import type { Book } from '@tsundoku-dragon/shared';
 
 vi.mock('nanoid', () => ({
@@ -258,9 +258,6 @@ describe('BookService', () => {
     it('存在しない本はNotFoundErrorを投げる', async () => {
       mockFindById.mockResolvedValueOnce(null);
 
-      await expect(service.getBook('user-123', 'not-exist')).rejects.toThrow(
-        NotFoundError
-      );
       await expect(
         service.getBook('user-123', 'not-exist')
       ).rejects.toMatchObject({ code: ErrorCode.BOOK_NOT_FOUND });
@@ -304,7 +301,7 @@ describe('BookService', () => {
 
       await expect(
         service.updateBook('user-123', 'not-exist', { title: '更新後' })
-      ).rejects.toThrow(NotFoundError);
+      ).rejects.toMatchObject({ code: ErrorCode.BOOK_NOT_FOUND });
       expect(mockUpdate).not.toHaveBeenCalled();
     });
 
@@ -366,7 +363,7 @@ describe('BookService', () => {
 
       await expect(
         service.archiveBook('user-123', 'not-exist')
-      ).rejects.toThrow(NotFoundError);
+      ).rejects.toMatchObject({ code: ErrorCode.BOOK_NOT_FOUND });
     });
 
     it('既にアーカイブ済みの本はエラー', async () => {
@@ -419,9 +416,9 @@ describe('BookService', () => {
     it('存在しない本はNotFoundErrorを投げる', async () => {
       mockFindById.mockResolvedValueOnce(null);
 
-      await expect(service.resetBook('user-123', 'not-exist')).rejects.toThrow(
-        NotFoundError
-      );
+      await expect(
+        service.resetBook('user-123', 'not-exist')
+      ).rejects.toMatchObject({ code: ErrorCode.BOOK_NOT_FOUND });
     });
 
     it('戦闘中の本はリセットできない', async () => {

--- a/apps/api/src/services/bookService.test.ts
+++ b/apps/api/src/services/bookService.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { BookService } from './bookService';
-import { BadRequestError, NotFoundError } from '../lib/errors';
+import { NotFoundError, ErrorCode } from '../lib/errors';
 import type { Book } from '@tsundoku-dragon/shared';
 
 vi.mock('nanoid', () => ({
@@ -261,6 +261,9 @@ describe('BookService', () => {
       await expect(service.getBook('user-123', 'not-exist')).rejects.toThrow(
         NotFoundError
       );
+      await expect(
+        service.getBook('user-123', 'not-exist')
+      ).rejects.toMatchObject({ code: ErrorCode.BOOK_NOT_FOUND });
     });
   });
 
@@ -310,7 +313,9 @@ describe('BookService', () => {
 
       await expect(
         service.updateBook('user-123', 'book-123', { title: '更新後' })
-      ).rejects.toThrow(BadRequestError);
+      ).rejects.toMatchObject({
+        code: ErrorCode.CANNOT_UPDATE_ARCHIVED_BOOK,
+      });
     });
 
     it('新規スキルをカスタムスキルに登録する', async () => {
@@ -367,9 +372,11 @@ describe('BookService', () => {
     it('既にアーカイブ済みの本はエラー', async () => {
       mockFindById.mockResolvedValueOnce({ ...mockBook, status: 'archived' });
 
-      await expect(service.archiveBook('user-123', 'book-123')).rejects.toThrow(
-        BadRequestError
-      );
+      await expect(
+        service.archiveBook('user-123', 'book-123')
+      ).rejects.toMatchObject({
+        code: ErrorCode.BOOK_IS_ALREADY_ARCHIVED,
+      });
     });
   });
 
@@ -423,9 +430,11 @@ describe('BookService', () => {
         status: 'reading',
       });
 
-      await expect(service.resetBook('user-123', 'book-123')).rejects.toThrow(
-        BadRequestError
-      );
+      await expect(
+        service.resetBook('user-123', 'book-123')
+      ).rejects.toMatchObject({
+        code: ErrorCode.CAN_ONLY_RESET_COMPLETED_BOOKS,
+      });
     });
   });
 });

--- a/apps/api/src/services/bookService.ts
+++ b/apps/api/src/services/bookService.ts
@@ -4,7 +4,7 @@ import { BookRepository } from '../repositories/bookRepository';
 import { SkillRepository } from '../repositories/skillRepository';
 import type { CreateBookInput, UpdateBookInput } from '../types/api';
 import type { Env } from '../lib/dynamodb';
-import { BadRequestError, NotFoundError } from '../lib/errors';
+import { BadRequestError, NotFoundError, ErrorCode } from '../lib/errors';
 
 export class BookService {
   private repository: BookRepository;
@@ -73,7 +73,7 @@ export class BookService {
   async getBook(userId: string, bookId: string): Promise<Book> {
     const book = await this.repository.findById(userId, bookId);
     if (!book) {
-      throw new NotFoundError('Book not found');
+      throw new NotFoundError(ErrorCode.BOOK_NOT_FOUND, 'Book not found');
     }
     return book;
   }
@@ -85,11 +85,14 @@ export class BookService {
   ): Promise<Book> {
     const book = await this.repository.findById(userId, bookId);
     if (!book) {
-      throw new NotFoundError('Book not found');
+      throw new NotFoundError(ErrorCode.BOOK_NOT_FOUND, 'Book not found');
     }
 
     if (book.status === 'archived') {
-      throw new BadRequestError('Cannot update archived book');
+      throw new BadRequestError(
+        ErrorCode.CANNOT_UPDATE_ARCHIVED_BOOK,
+        'Cannot update archived book'
+      );
     }
 
     const now = new Date().toISOString();
@@ -111,11 +114,14 @@ export class BookService {
   async archiveBook(userId: string, bookId: string): Promise<void> {
     const book = await this.repository.findById(userId, bookId);
     if (!book) {
-      throw new NotFoundError('Book not found');
+      throw new NotFoundError(ErrorCode.BOOK_NOT_FOUND, 'Book not found');
     }
 
     if (book.status === 'archived') {
-      throw new BadRequestError('Book is already archived');
+      throw new BadRequestError(
+        ErrorCode.BOOK_IS_ALREADY_ARCHIVED,
+        'Book is already archived'
+      );
     }
 
     const now = new Date().toISOString();
@@ -128,11 +134,14 @@ export class BookService {
   async resetBook(userId: string, bookId: string): Promise<Book> {
     const book = await this.repository.findById(userId, bookId);
     if (!book) {
-      throw new NotFoundError('Book not found');
+      throw new NotFoundError(ErrorCode.BOOK_NOT_FOUND, 'Book not found');
     }
 
     if (book.status !== 'completed') {
-      throw new BadRequestError('Can only reset completed books');
+      throw new BadRequestError(
+        ErrorCode.CAN_ONLY_RESET_COMPLETED_BOOKS,
+        'Can only reset completed books'
+      );
     }
 
     const now = new Date().toISOString();

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -95,6 +95,7 @@
 - staging 環境の Terraform 化（DynamoDB、IAM、KV Namespace、Cloudflare Access の既存リソース import）
 - production 環境の Terraform 化（DynamoDB、KV Namespace、Cloudflare Access の既存リソース import。IAM は staging で一元管理）
 - エラーハンドリング共通化（#76）（AppError/BadRequestError、handleError、app.onError、try-catch除去）
+- ErrorCode enum導入（#80）（構造化エラーコード、エラーレスポンスにcodeフィールド追加）
 
 ### 次にやること
 


### PR DESCRIPTION
## Summary

- `ErrorCode` enum を追加し、エラーの識別を文字列比較から型安全なコードベースに移行
- `AppError` / `BadRequestError` / `NotFoundError` に `code` プロパティを追加
- グローバルエラーハンドラ `handleError` のレスポンスに `code` フィールドを含めるように変更
- サービス層（bookService, battleService）の全エラー throw に適切な `ErrorCode` を指定
- 全テスト（errors, bookService, battleService, books routes, index）を ErrorCode 対応に更新

### エラーレスポンスの変更

```json
// Before
{ "error": "Book not found" }

// After
{ "error": "Book not found", "code": "BOOK_NOT_FOUND" }
```

### 導入した ErrorCode

| ErrorCode | 用途 |
|-----------|------|
| `BOOK_NOT_FOUND` | 本が見つからない (404) |
| `CANNOT_UPDATE_ARCHIVED_BOOK` | アーカイブ済みの本の更新 (400) |
| `BOOK_IS_ALREADY_ARCHIVED` | 既にアーカイブ済み (400) |
| `BOOK_NOT_IN_READING_STATUS` | 読書中でない本への戦闘記録 (400) |
| `CAN_ONLY_RESET_COMPLETED_BOOKS` | 未完了の本のリセット (400) |

closes #80

## Test plan

- [x] `npm run test` - 全288テスト (API 123 + Web 165) パス
- [x] `npm run lint` - エラーなし
- [x] `npm run typecheck` - エラーなし
- [x] `npm run format:check` - エラーなし

https://claude.ai/code/session_01HWT7VLwshGkyWw5QpbXXyt