### PR TITLE
feat: 書影取得をNDL書影APIから楽天ブックスAPIに移行

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -6,6 +6,7 @@ import { createDynamoDBClient, type Env } from './lib/dynamodb';
 import { handleError } from './lib/errors';
 import { authMiddleware } from './middleware/auth';
 import books from './routes/books';
+import covers from './routes/covers';
 import skills from './routes/skills';
 
 const app = new Hono<{ Bindings: Env }>();
@@ -31,6 +32,9 @@ app.route('/books', books);
 
 app.use('/skills', authMiddleware);
 app.route('/skills', skills);
+
+// 書影は<img src>から直接参照されるため認証なしで公開する
+app.route('/covers', covers);
 
 app.get('/', (c) => {
   return c.json({ message: 'Tsundoku Dragon API' });

--- a/apps/api/src/routes/covers.test.ts
+++ b/apps/api/src/routes/covers.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import covers from './covers';
+import { handleError } from '../lib/errors';
+
+const mockGetCoverImageUrl = vi.fn();
+
+vi.mock('../services/coverService', () => ({
+  CoverService: class {
+    getCoverImageUrl = mockGetCoverImageUrl;
+  },
+}));
+
+describe('Covers Routes', () => {
+  const mockEnv = {
+    RAKUTEN_APPLICATION_ID: 'test-app-id',
+  };
+
+  const app = new Hono();
+  app.route('/covers', covers);
+  app.onError(handleError);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('GET /covers/:isbn', () => {
+    it('書影が見つかった場合、画像URLへの302リダイレクトを返す', async () => {
+      mockGetCoverImageUrl.mockResolvedValueOnce(
+        'https://thumbnail.image.rakuten.co.jp/test.jpg?_ex=400x400'
+      );
+
+      const res = await app.request('/covers/9784798150727', {}, mockEnv);
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get('Location')).toBe(
+        'https://thumbnail.image.rakuten.co.jp/test.jpg?_ex=400x400'
+      );
+      expect(res.headers.get('Cache-Control')).toContain('max-age');
+      expect(mockGetCoverImageUrl).toHaveBeenCalledWith('9784798150727');
+    });
+
+    it('ハイフン付きISBNを正規化して検索する', async () => {
+      mockGetCoverImageUrl.mockResolvedValueOnce(null);
+
+      await app.request('/covers/978-4-7981-5072-7', {}, mockEnv);
+
+      expect(mockGetCoverImageUrl).toHaveBeenCalledWith('9784798150727');
+    });
+
+    it('書影が見つからない場合、404を返す', async () => {
+      mockGetCoverImageUrl.mockResolvedValueOnce(null);
+
+      const res = await app.request('/covers/9784798150727', {}, mockEnv);
+
+      expect(res.status).toBe(404);
+      expect(res.headers.get('Cache-Control')).toContain('max-age');
+    });
+
+    it('不正なISBNの場合、400を返す', async () => {
+      const res = await app.request('/covers/invalid-isbn', {}, mockEnv);
+
+      expect(res.status).toBe(400);
+      expect(mockGetCoverImageUrl).not.toHaveBeenCalled();
+    });
+
+    it('桁数が不正なISBNの場合、400を返す', async () => {
+      const res = await app.request('/covers/12345', {}, mockEnv);
+
+      expect(res.status).toBe(400);
+      expect(mockGetCoverImageUrl).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/routes/covers.ts
+++ b/apps/api/src/routes/covers.ts
@@ -1,0 +1,60 @@
+import { Hono } from 'hono';
+import type { Env } from '../types/env';
+import { CoverService } from '../services/coverService';
+
+const covers = new Hono<{ Bindings: Env }>();
+
+// 書影ありは30日キャッシュ。なしは後から書影が登録される可能性があるため1日に留める
+const FOUND_CACHE_CONTROL = 'public, max-age=2592000';
+const NOT_FOUND_CACHE_CONTROL = 'public, max-age=86400';
+
+function getEdgeCache(): Cache | undefined {
+  // ローカル・テスト環境ではCache APIが存在しない
+  return typeof caches !== 'undefined' ? caches.default : undefined;
+}
+
+covers.get('/:isbn', async (c) => {
+  const isbn = c.req.param('isbn').replace(/-/g, '');
+  if (!/^(\d{10}|\d{13})$/.test(isbn)) {
+    return c.json({ error: 'Invalid ISBN' }, 400);
+  }
+
+  // エッジキャッシュで楽天APIのレート制限（目安1req/秒）から保護する
+  const cache = getEdgeCache();
+  const cacheKey = new Request(c.req.url);
+  if (cache) {
+    const cached = await cache.match(cacheKey);
+    if (cached) {
+      return cached;
+    }
+  }
+
+  const service = new CoverService(c.env);
+  const imageUrl = await service.getCoverImageUrl(isbn);
+
+  // <img src>から直接参照できるよう、画像URLへの302リダイレクトで返す
+  const response = imageUrl
+    ? new Response(null, {
+        status: 302,
+        headers: {
+          Location: imageUrl,
+          'Cache-Control': FOUND_CACHE_CONTROL,
+        },
+      })
+    : c.json({ error: 'Cover not found' }, 404, {
+        'Cache-Control': NOT_FOUND_CACHE_CONTROL,
+      });
+
+  if (cache) {
+    const putPromise = cache.put(cacheKey, response.clone());
+    try {
+      c.executionCtx.waitUntil(putPromise);
+    } catch {
+      await putPromise;
+    }
+  }
+
+  return response;
+});
+
+export default covers;

--- a/apps/api/src/services/coverService.test.ts
+++ b/apps/api/src/services/coverService.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CoverService } from './coverService';
+import type { Env } from '../types/env';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function createEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    AWS_ACCESS_KEY_ID: 'test',
+    AWS_SECRET_ACCESS_KEY: 'test',
+    AWS_REGION: 'ap-northeast-1',
+    DYNAMODB_TABLE_NAME: 'test-table',
+    FIREBASE_PROJECT_ID: 'test-project',
+    PUBLIC_JWK_CACHE_KEY: 'test-cache-key',
+    PUBLIC_JWK_CACHE_KV: {} as KVNamespace,
+    RAKUTEN_APPLICATION_ID: 'test-app-id',
+    ...overrides,
+  };
+}
+
+function rakutenResponse(items: unknown[]): Response {
+  return new Response(JSON.stringify({ Items: items }), { status: 200 });
+}
+
+describe('CoverService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getCoverImageUrl', () => {
+    it('書影が見つかった場合、サイズを400x400に変更したURLを返す', async () => {
+      mockFetch.mockResolvedValueOnce(
+        rakutenResponse([
+          {
+            Item: {
+              largeImageUrl:
+                'https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0727/9784798150727.jpg?_ex=200x200',
+            },
+          },
+        ])
+      );
+
+      const service = new CoverService(createEnv());
+      const url = await service.getCoverImageUrl('9784798150727');
+
+      expect(url).toBe(
+        'https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0727/9784798150727.jpg?_ex=400x400'
+      );
+    });
+
+    it('楽天APIにISBN・アプリID・Refererを付けてリクエストする', async () => {
+      mockFetch.mockResolvedValueOnce(rakutenResponse([]));
+
+      const service = new CoverService(createEnv());
+      await service.getCoverImageUrl('9784798150727');
+
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toContain(
+        'https://app.rakuten.co.jp/services/api/BooksBook/Search/20170404'
+      );
+      expect(url).toContain('isbn=9784798150727');
+      expect(url).toContain('applicationId=test-app-id');
+      expect(init.headers).toMatchObject({
+        Referer: 'https://tsundoku.deepon.dev/',
+      });
+    });
+
+    it('検索結果が0件の場合、nullを返す', async () => {
+      mockFetch.mockResolvedValueOnce(rakutenResponse([]));
+
+      const service = new CoverService(createEnv());
+      const url = await service.getCoverImageUrl('9784798150727');
+
+      expect(url).toBeNull();
+    });
+
+    it('largeImageUrlがない場合、nullを返す', async () => {
+      mockFetch.mockResolvedValueOnce(rakutenResponse([{ Item: {} }]));
+
+      const service = new CoverService(createEnv());
+      const url = await service.getCoverImageUrl('9784798150727');
+
+      expect(url).toBeNull();
+    });
+
+    it('楽天APIがエラーレスポンスを返した場合、nullを返す', async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 'not_found' }), { status: 404 })
+      );
+
+      const service = new CoverService(createEnv());
+      const url = await service.getCoverImageUrl('9784798150727');
+
+      expect(url).toBeNull();
+    });
+
+    it('RAKUTEN_APPLICATION_IDが未設定の場合、APIを呼ばずnullを返す', async () => {
+      const service = new CoverService(
+        createEnv({ RAKUTEN_APPLICATION_ID: undefined })
+      );
+      const url = await service.getCoverImageUrl('9784798150727');
+
+      expect(url).toBeNull();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/services/coverService.ts
+++ b/apps/api/src/services/coverService.ts
@@ -1,0 +1,76 @@
+import type { Env } from '../types/env';
+
+const RAKUTEN_BOOKS_API_URL =
+  'https://app.rakuten.co.jp/services/api/BooksBook/Search/20170404';
+
+// 楽天ウェブサービスのアプリ登録で許可済みのドメイン（Allowed websites）。
+// サーバー間リクエストにはRefererが付かないため、許可リスト判定を通すよう明示的に付与する
+const RAKUTEN_REFERER = 'https://tsundoku.deepon.dev/';
+
+// largeImageUrlのデフォルトは200x200。UI表示用に十分な解像度へ引き上げる
+const COVER_IMAGE_SIZE = '400x400';
+
+interface RakutenBookItem {
+  Item: {
+    largeImageUrl?: string;
+  };
+}
+
+interface RakutenBooksSearchResponse {
+  Items?: RakutenBookItem[];
+}
+
+/**
+ * 楽天ブックス書籍検索APIから書影画像URLを取得するサービス
+ *
+ * NDL書影APIが2026-03-31で終了したため、書影取得は楽天APIで代替する。
+ * https://github.com/dznbk/tsundoku-dragon/issues/92
+ */
+export class CoverService {
+  constructor(private env: Env) {}
+
+  /**
+   * ISBNから書影画像URLを取得する
+   * @returns 書影URL。見つからない場合はnull
+   */
+  async getCoverImageUrl(isbn: string): Promise<string | null> {
+    const applicationId = this.env.RAKUTEN_APPLICATION_ID;
+    if (!applicationId) {
+      console.error('RAKUTEN_APPLICATION_ID is not configured');
+      return null;
+    }
+
+    const params = new URLSearchParams({
+      format: 'json',
+      isbn,
+      applicationId,
+      elements: 'largeImageUrl',
+    });
+
+    const response = await fetch(`${RAKUTEN_BOOKS_API_URL}?${params}`, {
+      headers: { Referer: RAKUTEN_REFERER },
+    });
+
+    // 楽天APIは検索結果0件を404で返すことがあるため、非2xxはすべて「書影なし」として扱う
+    if (!response.ok) {
+      return null;
+    }
+
+    const data = (await response.json()) as RakutenBooksSearchResponse;
+    const imageUrl = data.Items?.[0]?.Item?.largeImageUrl;
+    if (!imageUrl) {
+      return null;
+    }
+
+    return this.resizeImageUrl(imageUrl);
+  }
+
+  /**
+   * 楽天の画像URLのサイズ指定（?_ex=200x200）を差し替える
+   */
+  private resizeImageUrl(imageUrl: string): string {
+    const url = new URL(imageUrl);
+    url.searchParams.set('_ex', COVER_IMAGE_SIZE);
+    return url.toString();
+  }
+}

--- a/apps/api/src/types/env.ts
+++ b/apps/api/src/types/env.ts
@@ -15,4 +15,6 @@ export type Env = {
   FIREBASE_AUTH_EMULATOR_HOST?: string;
   // CORS
   ALLOWED_ORIGINS?: string;
+  // 楽天ウェブサービス（書影取得）
+  RAKUTEN_APPLICATION_ID?: string;
 };

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -14,6 +14,7 @@ PUBLIC_JWK_CACHE_KEY = "firebase-public-jwk-cache-key"
 # シークレットは wrangler secret put で設定:
 # wrangler secret put AWS_ACCESS_KEY_ID --env staging
 # wrangler secret put AWS_SECRET_ACCESS_KEY --env staging
+# wrangler secret put RAKUTEN_APPLICATION_ID --env staging
 
 # ============================================================
 # Staging 環境

--- a/apps/web/src/features/books/components/BattleTransition.tsx
+++ b/apps/web/src/features/books/components/BattleTransition.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
+import { getCoverUrl } from '../utils/coverUrl';
 import { getDragonColor, type DragonRank } from '../utils/dragonRank';
 import styles from './BattleTransition.module.css';
 
@@ -14,11 +15,6 @@ const COVER_DURATION = 1000;
 const CROSSFADE_DURATION = 500;
 const DRAGON_DURATION = 500;
 
-function getBookCoverUrl(isbn: string): string {
-  const cleanIsbn = isbn.replace(/-/g, '');
-  return `https://ndlsearch.ndl.go.jp/thumbnail/${cleanIsbn}.jpg`;
-}
-
 export function BattleTransition({
   isbn,
   rank,
@@ -29,9 +25,7 @@ export function BattleTransition({
   );
   const dragonColor = getDragonColor(rank);
 
-  const coverUrl = useMemo(() => {
-    return isbn ? getBookCoverUrl(isbn) : null;
-  }, [isbn]);
+  const coverUrl = useMemo(() => getCoverUrl(isbn), [isbn]);
 
   // フェーズ遷移
   useEffect(() => {

--- a/apps/web/src/features/books/components/BookCard.tsx
+++ b/apps/web/src/features/books/components/BookCard.tsx
@@ -1,4 +1,5 @@
 import type { Book } from '../services/bookApi';
+import { getCoverUrl } from '../utils/coverUrl';
 import { ProgressBar } from './ProgressBar';
 import { StatusBadge } from './StatusBadge';
 import styles from './BookCard.module.css';
@@ -8,15 +9,8 @@ interface BookCardProps {
   onClick?: () => void;
 }
 
-function getCoverUrl(isbn?: string): string {
-  if (!isbn) {
-    return '/assets/default-cover.png';
-  }
-  return `https://ndlsearch.ndl.go.jp/thumbnail/${isbn}.jpg`;
-}
-
 export function BookCard({ book, onClick }: BookCardProps) {
-  const coverUrl = getCoverUrl(book.isbn);
+  const coverUrl = getCoverUrl(book.isbn) ?? '/assets/default-cover.png';
 
   const handleClick = () => {
     if (onClick) {

--- a/apps/web/src/features/books/components/BookInfo.tsx
+++ b/apps/web/src/features/books/components/BookInfo.tsx
@@ -1,4 +1,5 @@
 import type { Book } from '../services/bookApi';
+import { getCoverUrl } from '../utils/coverUrl';
 import { ProgressBar } from './ProgressBar';
 import { StatusBadge } from './StatusBadge';
 import { DQButton } from '../../../components/DQButton';
@@ -12,13 +13,6 @@ interface BookInfoProps {
   onBattle: () => void;
 }
 
-function getCoverUrl(isbn?: string): string {
-  if (!isbn) {
-    return '/assets/default-cover.png';
-  }
-  return `https://ndlsearch.ndl.go.jp/thumbnail/${isbn}.jpg`;
-}
-
 export function BookInfo({
   book,
   onEdit,
@@ -26,7 +20,7 @@ export function BookInfo({
   onReset,
   onBattle,
 }: BookInfoProps) {
-  const coverUrl = getCoverUrl(book.isbn);
+  const coverUrl = getCoverUrl(book.isbn) ?? '/assets/default-cover.png';
   const isCompleted = book.status === 'completed';
   const isArchived = book.status === 'archived';
 

--- a/apps/web/src/features/books/services/ndlApi.test.ts
+++ b/apps/web/src/features/books/services/ndlApi.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { extractPagesFromExtent, fetchBooksByTitle } from './ndlApi';
 
+vi.stubEnv('VITE_API_URL', 'https://api.example.com');
+
 describe('ndlApi', () => {
   describe('extractPagesFromExtent', () => {
     it('"466p"から466を抽出する', () => {
@@ -69,7 +71,7 @@ describe('ndlApi', () => {
         author: 'テスト著者',
         isbn: '9784123456789',
         totalPages: 256,
-        coverUrl: 'https://ndlsearch.ndl.go.jp/thumbnail/9784123456789.jpg',
+        coverUrl: 'https://api.example.com/covers/9784123456789',
       });
     });
 

--- a/apps/web/src/features/books/services/ndlApi.ts
+++ b/apps/web/src/features/books/services/ndlApi.ts
@@ -1,3 +1,5 @@
+import { getCoverUrl } from '../utils/coverUrl';
+
 export interface NdlBookInfo {
   title: string | null;
   totalPages: number | null;
@@ -40,7 +42,7 @@ export async function fetchBookInfoByIsbn(isbn: string): Promise<NdlBookInfo> {
     const totalPages = pagesMatch ? parseInt(pagesMatch[1], 10) : null;
 
     // 書影URL
-    const coverUrl = `https://ndlsearch.ndl.go.jp/thumbnail/${cleanIsbn}.jpg`;
+    const coverUrl = getCoverUrl(cleanIsbn);
 
     return { title, totalPages, coverUrl };
   } catch {
@@ -149,9 +151,7 @@ export async function fetchBooksByTitle(
       const isbn = extractIsbnFromItem(item);
       const extent = item.querySelector('extent')?.textContent;
       const totalPages = extractPagesFromExtent(extent);
-      const coverUrl = isbn
-        ? `https://ndlsearch.ndl.go.jp/thumbnail/${isbn}.jpg`
-        : null;
+      const coverUrl = getCoverUrl(isbn);
 
       results.push({
         title: itemTitle,

--- a/apps/web/src/features/books/utils/coverUrl.test.ts
+++ b/apps/web/src/features/books/utils/coverUrl.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { getCoverUrl } from './coverUrl';
+
+describe('getCoverUrl', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_API_URL', 'https://api.example.com');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('ISBN-13から書影APIのURLを組み立てる', () => {
+    expect(getCoverUrl('9784798150727')).toBe(
+      'https://api.example.com/covers/9784798150727'
+    );
+  });
+
+  it('ISBN-10から書影APIのURLを組み立てる', () => {
+    expect(getCoverUrl('4798150720')).toBe(
+      'https://api.example.com/covers/4798150720'
+    );
+  });
+
+  it('ハイフン付きISBNを正規化する', () => {
+    expect(getCoverUrl('978-4-7981-5072-7')).toBe(
+      'https://api.example.com/covers/9784798150727'
+    );
+  });
+
+  it('ISBNがnullの場合はnullを返す', () => {
+    expect(getCoverUrl(null)).toBeNull();
+  });
+
+  it('ISBNがundefinedの場合はnullを返す', () => {
+    expect(getCoverUrl(undefined)).toBeNull();
+  });
+
+  it('ISBNが空文字の場合はnullを返す', () => {
+    expect(getCoverUrl('')).toBeNull();
+  });
+
+  it('桁数が不正なISBNの場合はnullを返す', () => {
+    expect(getCoverUrl('12345')).toBeNull();
+  });
+
+  it('数字以外を含むISBNの場合はnullを返す', () => {
+    expect(getCoverUrl('97847981507ab')).toBeNull();
+  });
+});

--- a/apps/web/src/features/books/utils/coverUrl.ts
+++ b/apps/web/src/features/books/utils/coverUrl.ts
@@ -1,0 +1,22 @@
+/**
+ * ISBNから書影画像URLを組み立てる
+ *
+ * NDL書影APIが2026-03-31で終了したため、書影はAPIの GET /covers/:isbn 経由で
+ * 楽天ブックスから取得する（エンドポイントが楽天の画像URLへ302リダイレクトする）。
+ * https://github.com/dznbk/tsundoku-dragon/issues/92
+ *
+ * @returns 書影URL。ISBNが無効な場合はnull
+ */
+export function getCoverUrl(isbn: string | null | undefined): string | null {
+  const cleanIsbn = isbn?.replace(/-/g, '') ?? '';
+  if (!/^(\d{10}|\d{13})$/.test(cleanIsbn)) {
+    return null;
+  }
+
+  const apiUrl = import.meta.env.VITE_API_URL;
+  if (!apiUrl) {
+    return null;
+  }
+
+  return `${apiUrl}/covers/${cleanIsbn}`;
+}


### PR DESCRIPTION
## 概要

NDL書影API（`https://ndlsearch.ndl.go.jp/thumbnail/{isbn}.jpg`）がJPROの規約改定に伴い2026-03-31でサービス終了し403を返すため、書影取得を楽天ブックス書籍検索APIで代替する。

Closes #92

## 変更内容

### API（Cloudflare Workers）

- `GET /covers/:isbn` を追加（`<img src>`から直接参照するため認証なしの公開エンドポイント）
  - `CoverService` が楽天ブックス書籍検索APIをISBNで叩き、`largeImageUrl` のサイズ指定を `_ex=400x400` に引き上げて返す
  - ルートは画像URLへの **302リダイレクト** で応答（書影あり: 30日キャッシュ / なし: 1日キャッシュ）
  - Cloudflareエッジキャッシュ（Cache API）で楽天のレート制限（目安1req/秒）を保護
  - 楽天のAllowed websites判定を通すため `Referer: https://tsundoku.deepon.dev/` を明示付与
- `RAKUTEN_APPLICATION_ID` を環境変数型・wrangler.tomlのシークレット手順に追加

### Web

- 書影URL組み立てを `features/books/utils/coverUrl.ts` に集約（`{VITE_API_URL}/covers/{isbn}` を返す）
- NDL URLを重複して組み立てていた4箇所（`ndlApi.ts` / `BookCard` / `BookInfo` / `BattleTransition`）を置換
- タイトル検索・ページ数取得は引き続きNDL opensearchを使用（書誌検索はサービス終了対象外）
- 書影はDB保存せずISBNから毎回導出しているため、既存登録済みの本もデプロイ後に自動で復旧する

## デプロイ前の作業（要手動）

```bash
cd apps/api
wrangler secret put RAKUTEN_APPLICATION_ID --env staging
wrangler secret put RAKUTEN_APPLICATION_ID --env production
```

ローカルは `apps/api/.dev.vars` の `RAKUTEN_APPLICATION_ID` に実際のアプリIDを記入する。

## テスト

- `./Taskfile check` 通過（lint / typecheck / unit 全パス）
- 追加: `coverService.test.ts`（6件）、`covers.test.ts`（5件）、`coverUrl.test.ts`（8件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpuxhVpHkNTdYMRdAhLRQs